### PR TITLE
Update ItemList and fix string matching issue

### DIFF
--- a/public/data/itemlist.json
+++ b/public/data/itemlist.json
@@ -1,6725 +1,5977 @@
-[
-  {
-    "item_url": "http://us.battle.net/d3/en/item/leorics-crown",
-    "url_name": "leorics-crown",
-    "api_url": "https://us.battle.net/api/d3/data/item/leorics-crown",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_002_p1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "legendary",
-    "name": "Leoric's Crown"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/prides-fall",
-    "url_name": "prides-fall",
-    "api_url": "https://us.battle.net/api/d3/data/item/prides-fall",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_103_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "legendary",
-    "name": "Pride's Fall"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/broken-crown",
-    "url_name": "broken-crown",
-    "api_url": "https://us.battle.net/api/d3/data/item/broken-crown",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_helm_001_demonhunter_male.png",
-    "type": "helm",
-    "quality": "legendary",
-    "name": "Broken Crown"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/cains-laurel",
-    "url_name": "cains-laurel",
-    "api_url": "https://us.battle.net/api/d3/data/item/cains-laurel",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_012_1xx_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Cain's Memory"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/blind-faith",
-    "url_name": "blind-faith",
-    "api_url": "https://us.battle.net/api/d3/data/item/blind-faith",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_007_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "legendary",
-    "name": "Blind Faith"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/deathseers-cowl",
-    "url_name": "deathseers-cowl",
-    "api_url": "https://us.battle.net/api/d3/data/item/deathseers-cowl",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_102_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "legendary",
-    "name": "Deathseer's Cowl"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/visage-of-gunes",
-    "url_name": "visage-of-gunes",
-    "api_url": "https://us.battle.net/api/d3/data/item/visage-of-gunes",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_helm_103_demonhunter_male.png",
-    "type": "helm",
-    "quality": "legendary",
-    "name": "Visage of Gunes"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/warhelm-of-kassar",
-    "url_name": "warhelm-of-kassar",
-    "api_url": "https://us.battle.net/api/d3/data/item/warhelm-of-kassar",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_helm_102_demonhunter_male.png",
-    "type": "helm",
-    "quality": "legendary",
-    "name": "Warhelm of Kassar"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/aughilds-brow",
-    "url_name": "aughilds-brow",
-    "api_url": "https://us.battle.net/api/d3/data/item/aughilds-brow",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_014_1xx_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Aughild's Peak"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/skull-of-resonance",
-    "url_name": "skull-of-resonance",
-    "api_url": "https://us.battle.net/api/d3/data/item/skull-of-resonance",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_004_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "legendary",
-    "name": "Skull of Resonance"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/guardians-watch",
-    "url_name": "guardians-watch",
-    "api_url": "https://us.battle.net/api/d3/data/item/guardians-watch",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_015_1xx_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Guardian's Foresight"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/andariels-visage",
-    "url_name": "andariels-visage",
-    "api_url": "https://us.battle.net/api/d3/data/item/andariels-visage",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_003_p2_demonhunter_male.png",
-    "type": "helm",
-    "quality": "legendary",
-    "name": "Andariel's Visage"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/mempo-of-twilight",
-    "url_name": "mempo-of-twilight",
-    "api_url": "https://us.battle.net/api/d3/data/item/mempo-of-twilight",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_006_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "legendary",
-    "name": "Mempo of Twilight"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/immortal-kings-triumph",
-    "url_name": "immortal-kings-triumph",
-    "api_url": "https://us.battle.net/api/d3/data/item/immortal-kings-triumph",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_008_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Immortal King's Triumph"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/natalyas-sight",
-    "url_name": "natalyas-sight",
-    "api_url": "https://us.battle.net/api/d3/data/item/natalyas-sight",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_009_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Natalya's Sight"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/tal-rashas-guise-of-wisdom",
-    "url_name": "tal-rashas-guise-of-wisdom",
-    "api_url": "https://us.battle.net/api/d3/data/item/tal-rashas-guise-of-wisdom",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_010_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Tal Rasha's Guise of Wisdom"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/the-helm-of-command",
-    "url_name": "the-helm-of-command",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-helm-of-command",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_011_1xx_demonhunter_male.png",
-    "type": "helm",
-    "quality": "legendary",
-    "name": "The Helm of Command"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/sages-stones",
-    "url_name": "sages-stones",
-    "api_url": "https://us.battle.net/api/d3/data/item/sages-stones",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_016_1xx_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Sage's Orbit"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/the-helm-of-rule",
-    "url_name": "the-helm-of-rule",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-helm-of-rule",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_011_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "legendary",
-    "name": "The Helm of Rule"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/accursed-visage",
-    "url_name": "accursed-visage",
-    "api_url": "https://us.battle.net/api/d3/data/item/accursed-visage",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_03_p2_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Accursed Visage"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/arachyrs-visage",
-    "url_name": "arachyrs-visage",
-    "api_url": "https://us.battle.net/api/d3/data/item/arachyrs-visage",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_02_p3_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Arachyr’s Visage"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/aughilds-spike",
-    "url_name": "aughilds-spike",
-    "api_url": "https://us.battle.net/api/d3/data/item/aughilds-spike",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_014_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Aughild's Spike"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/cains-insight",
-    "url_name": "cains-insight",
-    "api_url": "https://us.battle.net/api/d3/data/item/cains-insight",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_012_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Cain's Insight"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/crown-of-the-invoker",
-    "url_name": "crown-of-the-invoker",
-    "api_url": "https://us.battle.net/api/d3/data/item/crown-of-the-invoker",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_12_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Crown of the Invoker"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/crown-of-the-light",
-    "url_name": "crown-of-the-light",
-    "api_url": "https://us.battle.net/api/d3/data/item/crown-of-the-light",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_03_p3_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Crown of the Light"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/eyes-of-the-earth",
-    "url_name": "eyes-of-the-earth",
-    "api_url": "https://us.battle.net/api/d3/data/item/eyes-of-the-earth",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_15_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Eyes of the Earth"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/firebirds-plume",
-    "url_name": "firebirds-plume",
-    "api_url": "https://us.battle.net/api/d3/data/item/firebirds-plume",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_06_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Firebird's Plume"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/guardians-gaze",
-    "url_name": "guardians-gaze",
-    "api_url": "https://us.battle.net/api/d3/data/item/guardians-gaze",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_015_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Guardian's Gaze"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/helltooth-mask",
-    "url_name": "helltooth-mask",
-    "api_url": "https://us.battle.net/api/d3/data/item/helltooth-mask",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_16_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Helltooth Mask"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/helm-of-akkhan",
-    "url_name": "helm-of-akkhan",
-    "api_url": "https://us.battle.net/api/d3/data/item/helm-of-akkhan",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_10_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Helm of Akkhan"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/helm-of-the-wastes",
-    "url_name": "helm-of-the-wastes",
-    "api_url": "https://us.battle.net/api/d3/data/item/helm-of-the-wastes",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_01_p2_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Helm of the Wastes"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/jade-harvesters-wisdom",
-    "url_name": "jade-harvesters-wisdom",
-    "api_url": "https://us.battle.net/api/d3/data/item/jade-harvesters-wisdom",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_09_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Jade Harvester's Wisdom"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/marauders-visage",
-    "url_name": "marauders-visage",
-    "api_url": "https://us.battle.net/api/d3/data/item/marauders-visage",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_07_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Marauder's Visage"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/mask-of-the-searing-sky",
-    "url_name": "mask-of-the-searing-sky",
-    "api_url": "https://us.battle.net/api/d3/data/item/mask-of-the-searing-sky",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_08_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Mask of the Searing Sky"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/raekors-will",
-    "url_name": "raekors-will",
-    "api_url": "https://us.battle.net/api/d3/data/item/raekors-will",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_05_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Raekor's Will"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/rolands-visage",
-    "url_name": "rolands-visage",
-    "api_url": "https://us.battle.net/api/d3/data/item/rolands-visage",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_01_p1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Roland's Visage"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/sages-apogee",
-    "url_name": "sages-apogee",
-    "api_url": "https://us.battle.net/api/d3/data/item/sages-apogee",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_016_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Sage's Apogee"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/shrouded-mask",
-    "url_name": "shrouded-mask",
-    "api_url": "https://us.battle.net/api/d3/data/item/shrouded-mask",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_02_p2_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Shrouded Mask"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/sunwukos-crown",
-    "url_name": "sunwukos-crown",
-    "api_url": "https://us.battle.net/api/d3/data/item/sunwukos-crown",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_11_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Sunwuko's Crown"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-shadows-mask",
-    "url_name": "the-shadows-mask",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-shadows-mask",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_14_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "The Shadow's Mask"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/ulianas-spirit",
-    "url_name": "ulianas-spirit",
-    "api_url": "https://us.battle.net/api/d3/data/item/ulianas-spirit",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_01_p3_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Uliana's Spirit"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/vyrs-sightless-skull",
-    "url_name": "vyrs-sightless-skull",
-    "api_url": "https://us.battle.net/api/d3/data/item/vyrs-sightless-skull",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_13_x1_demonhunter_male.png",
-    "type": "helm",
-    "quality": "set",
-    "name": "Vyr's Sightless Skull"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/see-no-evil",
-    "url_name": "see-no-evil",
-    "api_url": "https://us.battle.net/api/d3/data/item/see-no-evil",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spiritstone_005_x1_demonhunter_male.png",
-    "type": "spirit-stone",
-    "quality": "legendary",
-    "name": "See No Evil"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/gyana-na-kashu",
-    "url_name": "gyana-na-kashu",
-    "api_url": "https://us.battle.net/api/d3/data/item/gyana-na-kashu",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spiritstone_004_x1_demonhunter_male.png",
-    "type": "spirit-stone",
-    "quality": "legendary",
-    "name": "Gyana Na Kashu"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/erlang-shen",
-    "url_name": "erlang-shen",
-    "api_url": "https://us.battle.net/api/d3/data/item/erlang-shen",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spiritstone_003_x1_demonhunter_male.png",
-    "type": "spirit-stone",
-    "quality": "legendary",
-    "name": "Erlang Shen"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-minds-eye",
-    "url_name": "the-minds-eye",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-minds-eye",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spiritstone_002_x1_demonhunter_male.png",
-    "type": "spirit-stone",
-    "quality": "legendary",
-    "name": "The Mind's Eye"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/eye-of-peshkov",
-    "url_name": "eye-of-peshkov",
-    "api_url": "https://us.battle.net/api/d3/data/item/eye-of-peshkov",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spiritstone_103_x1_demonhunter_male.png",
-    "type": "spirit-stone",
-    "quality": "legendary",
-    "name": "Eye of Peshkov"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/kekegis-unbreakable-spirit",
-    "url_name": "kekegis-unbreakable-spirit",
-    "api_url": "https://us.battle.net/api/d3/data/item/kekegis-unbreakable-spirit",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spiritstone_102_x1_demonhunter_male.png",
-    "type": "spirit-stone",
-    "quality": "legendary",
-    "name": "Kekegi's Unbreakable Spirit"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-laws-of-seph",
-    "url_name": "the-laws-of-seph",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-laws-of-seph",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spiritstone_101_x1_demonhunter_male.png",
-    "type": "spirit-stone",
-    "quality": "legendary",
-    "name": "The Laws of Seph"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/bezoar-stone",
-    "url_name": "bezoar-stone",
-    "api_url": "https://us.battle.net/api/d3/data/item/bezoar-stone",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spiritstone_001_x1_demonhunter_male.png",
-    "type": "spirit-stone",
-    "quality": "legendary",
-    "name": "Bezoar Stone"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-eye-of-the-storm",
-    "url_name": "the-eye-of-the-storm",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-eye-of-the-storm",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spiritstone_006_x1_demonhunter_male.png",
-    "type": "spirit-stone",
-    "quality": "legendary",
-    "name": "The Eye of the Storm"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/madstone",
-    "url_name": "madstone",
-    "api_url": "https://us.battle.net/api/d3/data/item/madstone",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p1_unique_spiritstone_008_demonhunter_male.png",
-    "type": "spirit-stone",
-    "quality": "legendary",
-    "name": "Madstone"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/tzo-krins-gaze",
-    "url_name": "tzo-krins-gaze",
-    "api_url": "https://us.battle.net/api/d3/data/item/tzo-krins-gaze",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spiritstone_007_x1_demonhunter_male.png",
-    "type": "spirit-stone",
-    "quality": "legendary",
-    "name": "Tzo Krin's Gaze"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/innas-radiance",
-    "url_name": "innas-radiance",
-    "api_url": "https://us.battle.net/api/d3/data/item/innas-radiance",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spiritstone_009_x1_demonhunter_male.png",
-    "type": "spirit-stone",
-    "quality": "set",
-    "name": "Inna's Radiance"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/split-tusk",
-    "url_name": "split-tusk",
-    "api_url": "https://us.battle.net/api/d3/data/item/split-tusk",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_voodoomask_006_x1_demonhunter_male.png",
-    "type": "voodoo-mask",
-    "quality": "legendary",
-    "name": "Split Tusk"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/quetzalcoatl",
-    "url_name": "quetzalcoatl",
-    "api_url": "https://us.battle.net/api/d3/data/item/quetzalcoatl",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_voodoomask_005_x1_demonhunter_male.png",
-    "type": "voodoo-mask",
-    "quality": "legendary",
-    "name": "Quetzalcoatl"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/carnevil",
-    "url_name": "carnevil",
-    "api_url": "https://us.battle.net/api/d3/data/item/carnevil",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_voodoomask_101_x1_demonhunter_male.png",
-    "type": "voodoo-mask",
-    "quality": "legendary",
-    "name": "Carnevil"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/mask-of-jeram",
-    "url_name": "mask-of-jeram",
-    "api_url": "https://us.battle.net/api/d3/data/item/mask-of-jeram",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_voodoomask_102_x1_demonhunter_male.png",
-    "type": "voodoo-mask",
-    "quality": "legendary",
-    "name": "Mask of Jeram"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-grin-reaper",
-    "url_name": "the-grin-reaper",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-grin-reaper",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_voodoomask_002_x1_demonhunter_male.png",
-    "type": "voodoo-mask",
-    "quality": "legendary",
-    "name": "The Grin Reaper"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/tiklandian-visage",
-    "url_name": "tiklandian-visage",
-    "api_url": "https://us.battle.net/api/d3/data/item/tiklandian-visage",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_voodoomask_001_x1_demonhunter_male.png",
-    "type": "voodoo-mask",
-    "quality": "legendary",
-    "name": "Tiklandian Visage"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/visage-of-giyua",
-    "url_name": "visage-of-giyua",
-    "api_url": "https://us.battle.net/api/d3/data/item/visage-of-giyua",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_voodoomask_008_x1_demonhunter_male.png",
-    "type": "voodoo-mask",
-    "quality": "legendary",
-    "name": "Visage of Giyua"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/zunimassas-vision",
-    "url_name": "zunimassas-vision",
-    "api_url": "https://us.battle.net/api/d3/data/item/zunimassas-vision",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_voodoomask_007_x1_demonhunter_male.png",
-    "type": "voodoo-mask",
-    "quality": "set",
-    "name": "Zunimassa's Vision"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/crown-of-the-primus",
-    "url_name": "crown-of-the-primus",
-    "api_url": "https://us.battle.net/api/d3/data/item/crown-of-the-primus",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wizardhat_104_x1_demonhunter_male.png",
-    "type": "wizard-hat",
-    "quality": "legendary",
-    "name": "Crown of the Primus"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-swami",
-    "url_name": "the-swami",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-swami",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_wizardhat_003_demonhunter_male.png",
-    "type": "wizard-hat",
-    "quality": "legendary",
-    "name": "The Swami"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/dark-mages-shade",
-    "url_name": "dark-mages-shade",
-    "api_url": "https://us.battle.net/api/d3/data/item/dark-mages-shade",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wizardhat_001_x1_demonhunter_male.png",
-    "type": "wizard-hat",
-    "quality": "legendary",
-    "name": "Dark Mage's Shade"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/archmages-vicalyke",
-    "url_name": "archmages-vicalyke",
-    "api_url": "https://us.battle.net/api/d3/data/item/archmages-vicalyke",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wizardhat_101_x1_demonhunter_male.png",
-    "type": "wizard-hat",
-    "quality": "legendary",
-    "name": "Archmage's Vicalyke"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-magistrate",
-    "url_name": "the-magistrate",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-magistrate",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wizardhat_103_x1_demonhunter_male.png",
-    "type": "wizard-hat",
-    "quality": "legendary",
-    "name": "The Magistrate"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/velvet-camaral",
-    "url_name": "velvet-camaral",
-    "api_url": "https://us.battle.net/api/d3/data/item/velvet-camaral",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wizardhat_102_x1_demonhunter_male.png",
-    "type": "wizard-hat",
-    "quality": "legendary",
-    "name": "Velvet Camaral"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/storm-crow",
-    "url_name": "storm-crow",
-    "api_url": "https://us.battle.net/api/d3/data/item/storm-crow",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wizardhat_004_x1_demonhunter_male.png",
-    "type": "wizard-hat",
-    "quality": "legendary",
-    "name": "Storm Crow"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/homing-pads",
-    "url_name": "homing-pads",
-    "api_url": "https://us.battle.net/api/d3/data/item/homing-pads",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_001_x1_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "legendary",
-    "name": "Homing Pads"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/pauldrons-of-the-skeleton-king",
-    "url_name": "pauldrons-of-the-skeleton-king",
-    "api_url": "https://us.battle.net/api/d3/data/item/pauldrons-of-the-skeleton-king",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_103_x1_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "legendary",
-    "name": "Pauldrons of the Skeleton King"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/borns-pauldrons",
-    "url_name": "borns-pauldrons",
-    "api_url": "https://us.battle.net/api/d3/data/item/borns-pauldrons",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_006_1xx_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Born's Impunity"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/death-watch-mantle",
-    "url_name": "death-watch-mantle",
-    "api_url": "https://us.battle.net/api/d3/data/item/death-watch-mantle",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_002_p2_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "legendary",
-    "name": "Death Watch Mantle"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/fury-of-the-ancients",
-    "url_name": "fury-of-the-ancients",
-    "api_url": "https://us.battle.net/api/d3/data/item/fury-of-the-ancients",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_shoulder_102_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "legendary",
-    "name": "Fury of the Ancients"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/lefebvres-soliloquy",
-    "url_name": "lefebvres-soliloquy",
-    "api_url": "https://us.battle.net/api/d3/data/item/lefebvres-soliloquy",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_shoulder_101_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "legendary",
-    "name": "Lefebvre’s Soliloquy"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/mantle-of-channeling",
-    "url_name": "mantle-of-channeling",
-    "api_url": "https://us.battle.net/api/d3/data/item/mantle-of-channeling",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_shoulder_103_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "legendary",
-    "name": "Mantle of Channeling"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/spaulders-of-zakara",
-    "url_name": "spaulders-of-zakara",
-    "api_url": "https://us.battle.net/api/d3/data/item/spaulders-of-zakara",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_102_x1_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "legendary",
-    "name": "Spaulders of Zakara"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/aughilds-triumph",
-    "url_name": "aughilds-triumph",
-    "api_url": "https://us.battle.net/api/d3/data/item/aughilds-triumph",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_008_1xx_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Aughild's Reign"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/ashearas-vigilance",
-    "url_name": "ashearas-vigilance",
-    "api_url": "https://us.battle.net/api/d3/data/item/ashearas-vigilance",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_017_1xx_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Asheara's Guard"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/vile-ward",
-    "url_name": "vile-ward",
-    "api_url": "https://us.battle.net/api/d3/data/item/vile-ward",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_003_p1_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "legendary",
-    "name": "Vile Ward"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/seven-sins",
-    "url_name": "seven-sins",
-    "api_url": "https://us.battle.net/api/d3/data/item/seven-sins",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_007_1xx_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "legendary",
-    "name": "Seven Sins"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demons-wings",
-    "url_name": "demons-wings",
-    "api_url": "https://us.battle.net/api/d3/data/item/demons-wings",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_009_1xx_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Demon's Flight"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/corruption",
-    "url_name": "corruption",
-    "api_url": "https://us.battle.net/api/d3/data/item/corruption",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_007_x1_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "legendary",
-    "name": "Corruption"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/arachyrs-mantle",
-    "url_name": "arachyrs-mantle",
-    "api_url": "https://us.battle.net/api/d3/data/item/arachyrs-mantle",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_02_p3_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Arachyr’s Mantle"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/ashearas-custodian",
-    "url_name": "ashearas-custodian",
-    "api_url": "https://us.battle.net/api/d3/data/item/ashearas-custodian",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_017_x1_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Asheara's Custodian"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/aughilds-power",
-    "url_name": "aughilds-power",
-    "api_url": "https://us.battle.net/api/d3/data/item/aughilds-power",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_008_x1_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Aughild's Power"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/borns-privilege",
-    "url_name": "borns-privilege",
-    "api_url": "https://us.battle.net/api/d3/data/item/borns-privilege",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_006_x1_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Born's Privilege"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/burden-of-the-invoker",
-    "url_name": "burden-of-the-invoker",
-    "api_url": "https://us.battle.net/api/d3/data/item/burden-of-the-invoker",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_12_x1_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Burden of the Invoker"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/dashing-pauldrons-of-despair",
-    "url_name": "dashing-pauldrons-of-despair",
-    "api_url": "https://us.battle.net/api/d3/data/item/dashing-pauldrons-of-despair",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_02_p2_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Dashing Pauldrons of Despair"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demons-aileron",
-    "url_name": "demons-aileron",
-    "api_url": "https://us.battle.net/api/d3/data/item/demons-aileron",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_009_x1_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Demon's Aileron"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/firebirds-pinions",
-    "url_name": "firebirds-pinions",
-    "api_url": "https://us.battle.net/api/d3/data/item/firebirds-pinions",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_06_x1_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Firebird's Pinions"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/helltooth-mantle",
-    "url_name": "helltooth-mantle",
-    "api_url": "https://us.battle.net/api/d3/data/item/helltooth-mantle",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_16_x1_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Helltooth Mantle"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/jade-harvesters-joy",
-    "url_name": "jade-harvesters-joy",
-    "api_url": "https://us.battle.net/api/d3/data/item/jade-harvesters-joy",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_09_x1_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Jade Harvester's Joy"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/mantle-of-the-upsidedown-sinners",
-    "url_name": "mantle-of-the-upsidedown-sinners",
-    "api_url": "https://us.battle.net/api/d3/data/item/mantle-of-the-upsidedown-sinners",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_08_x1_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Mantle of the Upside-Down Sinners"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/marauders-spines",
-    "url_name": "marauders-spines",
-    "api_url": "https://us.battle.net/api/d3/data/item/marauders-spines",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_07_x1_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Marauder's Spines"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/mountain-of-the-light",
-    "url_name": "mountain-of-the-light",
-    "api_url": "https://us.battle.net/api/d3/data/item/mountain-of-the-light",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_03_p3_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Mountain of the Light"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/pauldrons-of-akkhan",
-    "url_name": "pauldrons-of-akkhan",
-    "api_url": "https://us.battle.net/api/d3/data/item/pauldrons-of-akkhan",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_10_x1_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Pauldrons of Akkhan"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/pauldrons-of-the-wastes",
-    "url_name": "pauldrons-of-the-wastes",
-    "api_url": "https://us.battle.net/api/d3/data/item/pauldrons-of-the-wastes",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_01_p2_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Pauldrons of the Wastes"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/raekors-burden",
-    "url_name": "raekors-burden",
-    "api_url": "https://us.battle.net/api/d3/data/item/raekors-burden",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_05_x1_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Raekor's Burden"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/rolands-mantle",
-    "url_name": "rolands-mantle",
-    "api_url": "https://us.battle.net/api/d3/data/item/rolands-mantle",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_01_p1_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Roland's Mantle"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/spires-of-the-earth",
-    "url_name": "spires-of-the-earth",
-    "api_url": "https://us.battle.net/api/d3/data/item/spires-of-the-earth",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_15_x1_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Spires of the Earth"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/sunwukos-balance",
-    "url_name": "sunwukos-balance",
-    "api_url": "https://us.battle.net/api/d3/data/item/sunwukos-balance",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_11_x1_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Sunwuko's Balance"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-shadows-burden",
-    "url_name": "the-shadows-burden",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-shadows-burden",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_14_x1_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "The Shadow's Burden"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/ulianas-strength",
-    "url_name": "ulianas-strength",
-    "api_url": "https://us.battle.net/api/d3/data/item/ulianas-strength",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_01_p3_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Uliana's Strength"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/unsanctified-shoulders",
-    "url_name": "unsanctified-shoulders",
-    "api_url": "https://us.battle.net/api/d3/data/item/unsanctified-shoulders",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_03_p2_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Unsanctified Shoulders"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/vyrs-proud-pauldrons",
-    "url_name": "vyrs-proud-pauldrons",
-    "api_url": "https://us.battle.net/api/d3/data/item/vyrs-proud-pauldrons",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_13_x1_demonhunter_male.png",
-    "type": "pauldrons",
-    "quality": "set",
-    "name": "Vyr's Proud Pauldrons"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/heart-of-iron",
-    "url_name": "heart-of-iron",
-    "api_url": "https://us.battle.net/api/d3/data/item/heart-of-iron",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_chest_018_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "legendary",
-    "name": "Heart of Iron"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/aquila-cuirass",
-    "url_name": "aquila-cuirass",
-    "api_url": "https://us.battle.net/api/d3/data/item/aquila-cuirass",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_chest_012_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "legendary",
-    "name": "Aquila Cuirass"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/borns-carapace",
-    "url_name": "borns-carapace",
-    "api_url": "https://us.battle.net/api/d3/data/item/borns-carapace",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_025_1xx_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Born's Heart of Steel"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/chaingmail",
-    "url_name": "chaingmail",
-    "api_url": "https://us.battle.net/api/d3/data/item/chaingmail",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_010_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "legendary",
-    "name": "Chaingmail"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/cindercoat",
-    "url_name": "cindercoat",
-    "api_url": "https://us.battle.net/api/d3/data/item/cindercoat",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_006_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "legendary",
-    "name": "Cindercoat"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/shi-mizus-haori",
-    "url_name": "shi-mizus-haori",
-    "api_url": "https://us.battle.net/api/d3/data/item/shi-mizus-haori",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_101_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "legendary",
-    "name": "Shi Mizu's Haori"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/aughilds-vestments",
-    "url_name": "aughilds-vestments",
-    "api_url": "https://us.battle.net/api/d3/data/item/aughilds-vestments",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_026_1xx_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Aughild's Dominion"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/goldskin",
-    "url_name": "goldskin",
-    "api_url": "https://us.battle.net/api/d3/data/item/goldskin",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_001_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "legendary",
-    "name": "Goldskin"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/tyraels-might",
-    "url_name": "tyraels-might",
-    "api_url": "https://us.battle.net/api/d3/data/item/tyraels-might",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_002_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "legendary",
-    "name": "Tyrael's Might"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/blackthornes-surcoat",
-    "url_name": "blackthornes-surcoat",
-    "api_url": "https://us.battle.net/api/d3/data/item/blackthornes-surcoat",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chestarmor_028_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Blackthorne's Surcoat"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/immortal-kings-eternal-reign",
-    "url_name": "immortal-kings-eternal-reign",
-    "api_url": "https://us.battle.net/api/d3/data/item/immortal-kings-eternal-reign",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_013_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Immortal King's Eternal Reign"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/innas-vast-expanse",
-    "url_name": "innas-vast-expanse",
-    "api_url": "https://us.battle.net/api/d3/data/item/innas-vast-expanse",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_015_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Inna's Vast Expanse"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/tal-rashas-relentless-pursuit",
-    "url_name": "tal-rashas-relentless-pursuit",
-    "api_url": "https://us.battle.net/api/d3/data/item/tal-rashas-relentless-pursuit",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_014_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Tal Rasha's Relentless Pursuit"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/zunimassas-marrow",
-    "url_name": "zunimassas-marrow",
-    "api_url": "https://us.battle.net/api/d3/data/item/zunimassas-marrow",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_016_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Zunimassa's Marrow"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/robes-of-the-rydraelm",
-    "url_name": "robes-of-the-rydraelm",
-    "api_url": "https://us.battle.net/api/d3/data/item/robes-of-the-rydraelm",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_019_1xx_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "legendary",
-    "name": "Robes of the Rydraelm"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demons-cage",
-    "url_name": "demons-cage",
-    "api_url": "https://us.battle.net/api/d3/data/item/demons-cage",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_027_1xx_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Demon's Heart"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/armor-of-the-kind-regent",
-    "url_name": "armor-of-the-kind-regent",
-    "api_url": "https://us.battle.net/api/d3/data/item/armor-of-the-kind-regent",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_102_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "legendary",
-    "name": "Armor of the Kind Regent"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/mantle-of-the-rydraelm",
-    "url_name": "mantle-of-the-rydraelm",
-    "api_url": "https://us.battle.net/api/d3/data/item/mantle-of-the-rydraelm",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_019_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "legendary",
-    "name": "Mantle of the Rydraelm"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/arachyrs-carapace",
-    "url_name": "arachyrs-carapace",
-    "api_url": "https://us.battle.net/api/d3/data/item/arachyrs-carapace",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_02_p3_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Arachyr’s Carapace"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/aughilds-rule",
-    "url_name": "aughilds-rule",
-    "api_url": "https://us.battle.net/api/d3/data/item/aughilds-rule",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_026_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Aughild's Rule"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/borns-frozen-soul",
-    "url_name": "borns-frozen-soul",
-    "api_url": "https://us.battle.net/api/d3/data/item/borns-frozen-soul",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_025_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Born's Frozen Soul"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/breastplate-of-akkhan",
-    "url_name": "breastplate-of-akkhan",
-    "api_url": "https://us.battle.net/api/d3/data/item/breastplate-of-akkhan",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_10_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Breastplate of Akkhan"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/cuirass-of-the-wastes",
-    "url_name": "cuirass-of-the-wastes",
-    "api_url": "https://us.battle.net/api/d3/data/item/cuirass-of-the-wastes",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_01_p2_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Cuirass of the Wastes"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demons-marrow",
-    "url_name": "demons-marrow",
-    "api_url": "https://us.battle.net/api/d3/data/item/demons-marrow",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_027_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Demon's Marrow"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/firebirds-breast",
-    "url_name": "firebirds-breast",
-    "api_url": "https://us.battle.net/api/d3/data/item/firebirds-breast",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_06_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Firebird's Breast"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/harness-of-truth",
-    "url_name": "harness-of-truth",
-    "api_url": "https://us.battle.net/api/d3/data/item/harness-of-truth",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_02_p2_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Harness of Truth"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/heart-of-the-crashing-wave",
-    "url_name": "heart-of-the-crashing-wave",
-    "api_url": "https://us.battle.net/api/d3/data/item/heart-of-the-crashing-wave",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_08_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Heart of the Crashing Wave"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/heart-of-the-light",
-    "url_name": "heart-of-the-light",
-    "api_url": "https://us.battle.net/api/d3/data/item/heart-of-the-light",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_03_p3_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Heart of the Light"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/helltooth-tunic",
-    "url_name": "helltooth-tunic",
-    "api_url": "https://us.battle.net/api/d3/data/item/helltooth-tunic",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_16_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Helltooth Tunic"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/jade-harvesters-peace",
-    "url_name": "jade-harvesters-peace",
-    "api_url": "https://us.battle.net/api/d3/data/item/jade-harvesters-peace",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_09_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Jade Harvester's Peace"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/marauders-carapace",
-    "url_name": "marauders-carapace",
-    "api_url": "https://us.battle.net/api/d3/data/item/marauders-carapace",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_07_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Marauder's Carapace"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/raekors-heart",
-    "url_name": "raekors-heart",
-    "api_url": "https://us.battle.net/api/d3/data/item/raekors-heart",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_05_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Raekor's Heart"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/rolands-bearing",
-    "url_name": "rolands-bearing",
-    "api_url": "https://us.battle.net/api/d3/data/item/rolands-bearing",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_01_p1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Roland's Bearing"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/spirit-of-the-earth",
-    "url_name": "spirit-of-the-earth",
-    "api_url": "https://us.battle.net/api/d3/data/item/spirit-of-the-earth",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_15_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Spirit of the Earth"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/sunwukos-soul",
-    "url_name": "sunwukos-soul",
-    "api_url": "https://us.battle.net/api/d3/data/item/sunwukos-soul",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_11_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Sunwuko's Soul"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-shadows-bane",
-    "url_name": "the-shadows-bane",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-shadows-bane",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_14_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "The Shadow's Bane"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/ulianas-heart",
-    "url_name": "ulianas-heart",
-    "api_url": "https://us.battle.net/api/d3/data/item/ulianas-heart",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_01_p3_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Uliana's Heart"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/vyrs-astonishing-aura",
-    "url_name": "vyrs-astonishing-aura",
-    "api_url": "https://us.battle.net/api/d3/data/item/vyrs-astonishing-aura",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_13_x1_demonhunter_male.png",
-    "type": "chest-armor",
-    "quality": "set",
-    "name": "Vyr's Astonishing Aura"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/cloak-of-deception",
-    "url_name": "cloak-of-deception",
-    "api_url": "https://us.battle.net/api/d3/data/item/cloak-of-deception",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_cloak_102_x1_demonhunter_male.png",
-    "type": "cloak",
-    "quality": "legendary",
-    "name": "Cloak of Deception"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/beckon-sail",
-    "url_name": "beckon-sail",
-    "api_url": "https://us.battle.net/api/d3/data/item/beckon-sail",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_cloak_005_x1_demonhunter_male.png",
-    "type": "cloak",
-    "quality": "legendary",
-    "name": "Beckon Sail"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/blackfeather",
-    "url_name": "blackfeather",
-    "api_url": "https://us.battle.net/api/d3/data/item/blackfeather",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_cloak_101_x1_demonhunter_male.png",
-    "type": "cloak",
-    "quality": "legendary",
-    "name": "Blackfeather"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/cape-of-the-dark-night",
-    "url_name": "cape-of-the-dark-night",
-    "api_url": "https://us.battle.net/api/d3/data/item/cape-of-the-dark-night",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_cloak_001_x1_demonhunter_male.png",
-    "type": "cloak",
-    "quality": "legendary",
-    "name": "Cape of the Dark Night"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-cloak-of-the-garwulf",
-    "url_name": "the-cloak-of-the-garwulf",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-cloak-of-the-garwulf",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_cloak_002_p1_demonhunter_male.png",
-    "type": "cloak",
-    "quality": "legendary",
-    "name": "The Cloak of the Garwulf"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/natalyas-embrace",
-    "url_name": "natalyas-embrace",
-    "api_url": "https://us.battle.net/api/d3/data/item/natalyas-embrace",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_cloak_006_x1_demonhunter_male.png",
-    "type": "cloak",
-    "quality": "set",
-    "name": "Natalya's Embrace"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/cage-of-the-hellborn",
-    "url_name": "cage-of-the-hellborn",
-    "api_url": "https://us.battle.net/api/d3/data/item/cage-of-the-hellborn",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_03_p2_demonhunter_male.png",
-    "type": "cloak",
-    "quality": "set",
-    "name": "Cage of the Hellborn"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/ashnagarrs-blood-bracer",
-    "url_name": "ashnagarrs-blood-bracer",
-    "api_url": "https://us.battle.net/api/d3/data/item/ashnagarrs-blood-bracer",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_bracer_004_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Ashnagarr’s Blood Bracer"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/cesars-memento",
-    "url_name": "cesars-memento",
-    "api_url": "https://us.battle.net/api/d3/data/item/cesars-memento",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_bracer_107_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Cesar’s Memento"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/gungdo-gear",
-    "url_name": "gungdo-gear",
-    "api_url": "https://us.battle.net/api/d3/data/item/gungdo-gear",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_bracer_006_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Gungdo Gear"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/bracers-of-destruction",
-    "url_name": "bracers-of-destruction",
-    "api_url": "https://us.battle.net/api/d3/data/item/bracers-of-destruction",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_bracer_104_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Bracers of Destruction"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/bracers-of-the-first-men",
-    "url_name": "bracers-of-the-first-men",
-    "api_url": "https://us.battle.net/api/d3/data/item/bracers-of-the-first-men",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_bracer_105_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Bracers of the First Men"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/gabriels-vambraces",
-    "url_name": "gabriels-vambraces",
-    "api_url": "https://us.battle.net/api/d3/data/item/gabriels-vambraces",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_bracer_101_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Gabriel's Vambraces"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/jerams-bracers",
-    "url_name": "jerams-bracers",
-    "api_url": "https://us.battle.net/api/d3/data/item/jerams-bracers",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_bracer_106_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Jeram's Bracers"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/pintos-pride",
-    "url_name": "pintos-pride",
-    "api_url": "https://us.battle.net/api/d3/data/item/pintos-pride",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_bracer_105_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Pinto's Pride"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/sanguinary-vambraces",
-    "url_name": "sanguinary-vambraces",
-    "api_url": "https://us.battle.net/api/d3/data/item/sanguinary-vambraces",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_105_x1_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Sanguinary Vambraces"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/wraps-of-clarity",
-    "url_name": "wraps-of-clarity",
-    "api_url": "https://us.battle.net/api/d3/data/item/wraps-of-clarity",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_bracer_103_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Wraps of Clarity"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/bindings-of-the-lesser-gods",
-    "url_name": "bindings-of-the-lesser-gods",
-    "api_url": "https://us.battle.net/api/d3/data/item/bindings-of-the-lesser-gods",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_bracer_108_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Bindings of the Lesser Gods"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/akkhans-manacles",
-    "url_name": "akkhans-manacles",
-    "api_url": "https://us.battle.net/api/d3/data/item/akkhans-manacles",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_bracer_103_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Akkhan’s Manacles"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/bracer-of-fury",
-    "url_name": "bracer-of-fury",
-    "api_url": "https://us.battle.net/api/d3/data/item/bracer-of-fury",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_bracer_104_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Bracer of Fury"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/vambraces-of-sescheron",
-    "url_name": "vambraces-of-sescheron",
-    "api_url": "https://us.battle.net/api/d3/data/item/vambraces-of-sescheron",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_bracer_106_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Vambraces of Sescheron"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/ancient-parthan-defenders",
-    "url_name": "ancient-parthan-defenders",
-    "api_url": "https://us.battle.net/api/d3/data/item/ancient-parthan-defenders",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_102_x1_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Ancient Parthan Defenders"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/custerian-wristguards",
-    "url_name": "custerian-wristguards",
-    "api_url": "https://us.battle.net/api/d3/data/item/custerian-wristguards",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_107_x1_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Custerian Wristguards"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/nemesis-bracers",
-    "url_name": "nemesis-bracers",
-    "api_url": "https://us.battle.net/api/d3/data/item/nemesis-bracers",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_106_x1_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Nemesis Bracers"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/warzechian-armguards",
-    "url_name": "warzechian-armguards",
-    "api_url": "https://us.battle.net/api/d3/data/item/warzechian-armguards",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_101_x1_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Warzechian Armguards"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/aughilds-demands",
-    "url_name": "aughilds-demands",
-    "api_url": "https://us.battle.net/api/d3/data/item/aughilds-demands",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_009_1xx_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "set",
-    "name": "Aughild's Ultimatum"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/promise-of-glory",
-    "url_name": "promise-of-glory",
-    "api_url": "https://us.battle.net/api/d3/data/item/promise-of-glory",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_002_x1_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Promise of Glory"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/guardians-bands",
-    "url_name": "guardians-bands",
-    "api_url": "https://us.battle.net/api/d3/data/item/guardians-bands",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_010_1xx_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "set",
-    "name": "Guardian's Deflector"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/lacuni-prowlers",
-    "url_name": "lacuni-prowlers",
-    "api_url": "https://us.battle.net/api/d3/data/item/lacuni-prowlers",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_005_x1_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Lacuni Prowlers"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/strongarm-bracers",
-    "url_name": "strongarm-bracers",
-    "api_url": "https://us.battle.net/api/d3/data/item/strongarm-bracers",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_007_x1_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Strongarm Bracers"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/wondrous-deflectors",
-    "url_name": "wondrous-deflectors",
-    "api_url": "https://us.battle.net/api/d3/data/item/wondrous-deflectors",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_001_1xx_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Wondrous Deflectors"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demons-manacles",
-    "url_name": "demons-manacles",
-    "api_url": "https://us.battle.net/api/d3/data/item/demons-manacles",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_011_1xx_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "set",
-    "name": "Demon's Revenge"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/coils-of-the-first-spider",
-    "url_name": "coils-of-the-first-spider",
-    "api_url": "https://us.battle.net/api/d3/data/item/coils-of-the-first-spider",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_bracer_107_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Coils of the First Spider"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/drakons-lesson",
-    "url_name": "drakons-lesson",
-    "api_url": "https://us.battle.net/api/d3/data/item/drakons-lesson",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_bracer_110_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Drakon's Lesson"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/kethryes-splint",
-    "url_name": "kethryes-splint",
-    "api_url": "https://us.battle.net/api/d3/data/item/kethryes-splint",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_001_x1_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Kethryes' Splint"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/lakumbas-ornament",
-    "url_name": "lakumbas-ornament",
-    "api_url": "https://us.battle.net/api/d3/data/item/lakumbas-ornament",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_bracer_102_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Lakumba’s Ornament"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/ranslors-folly",
-    "url_name": "ranslors-folly",
-    "api_url": "https://us.battle.net/api/d3/data/item/ranslors-folly",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_108_x1_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Ranslor's Folly"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/reapers-wraps",
-    "url_name": "reapers-wraps",
-    "api_url": "https://us.battle.net/api/d3/data/item/reapers-wraps",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_103_x1_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Reaper's Wraps"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/skulars-salvation",
-    "url_name": "skulars-salvation",
-    "api_url": "https://us.battle.net/api/d3/data/item/skulars-salvation",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_bracer_101_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Skular's Salvation"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/spirit-guards",
-    "url_name": "spirit-guards",
-    "api_url": "https://us.battle.net/api/d3/data/item/spirit-guards",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_bracer_109_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Spirit Guards"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/tragoul-coils",
-    "url_name": "tragoul-coils",
-    "api_url": "https://us.battle.net/api/d3/data/item/tragoul-coils",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_104_x1_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "legendary",
-    "name": "Trag'Oul Coils"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/aughilds-search",
-    "url_name": "aughilds-search",
-    "api_url": "https://us.battle.net/api/d3/data/item/aughilds-search",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_009_x1_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "set",
-    "name": "Aughild's Search"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demons-animus",
-    "url_name": "demons-animus",
-    "api_url": "https://us.battle.net/api/d3/data/item/demons-animus",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_011_x1_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "set",
-    "name": "Demon's Animus"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/guardians-aversion",
-    "url_name": "guardians-aversion",
-    "api_url": "https://us.battle.net/api/d3/data/item/guardians-aversion",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_010_x1_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "set",
-    "name": "Guardian's Aversion"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/krelms-buff-bracers",
-    "url_name": "krelms-buff-bracers",
-    "api_url": "https://us.battle.net/api/d3/data/item/krelms-buff-bracers",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_set_02_x1_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "set",
-    "name": "Krelm's Buff Bracers"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/shackles-of-the-invoker",
-    "url_name": "shackles-of-the-invoker",
-    "api_url": "https://us.battle.net/api/d3/data/item/shackles-of-the-invoker",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_set_12_x1_demonhunter_male.png",
-    "type": "bracers",
-    "quality": "set",
-    "name": "Shackles of the Invoker"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/gloves-of-worship",
-    "url_name": "gloves-of-worship",
-    "api_url": "https://us.battle.net/api/d3/data/item/gloves-of-worship",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_103_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "legendary",
-    "name": "Gloves of Worship"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/cains-warmers",
-    "url_name": "cains-warmers",
-    "api_url": "https://us.battle.net/api/d3/data/item/cains-warmers",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_015_1xx_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Cain's Scribe"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/stone-gauntlets",
-    "url_name": "stone-gauntlets",
-    "api_url": "https://us.battle.net/api/d3/data/item/stone-gauntlets",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_007_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "legendary",
-    "name": "Stone Gauntlets"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/magefist",
-    "url_name": "magefist",
-    "api_url": "https://us.battle.net/api/d3/data/item/magefist",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_014_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "legendary",
-    "name": "Magefist"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/st-archews-gage",
-    "url_name": "st-archews-gage",
-    "api_url": "https://us.battle.net/api/d3/data/item/st-archews-gage",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_101_p2_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "legendary",
-    "name": "St. Archew's Gage"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/pendergrasps",
-    "url_name": "pendergrasps",
-    "api_url": "https://us.battle.net/api/d3/data/item/pendergrasps",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_001_1xx_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "legendary",
-    "name": "Pendergrasps"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/gladiator-gauntlets",
-    "url_name": "gladiator-gauntlets",
-    "api_url": "https://us.battle.net/api/d3/data/item/gladiator-gauntlets",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_011_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "legendary",
-    "name": "Gladiator Gauntlets"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/ashearas-clasp",
-    "url_name": "ashearas-clasp",
-    "api_url": "https://us.battle.net/api/d3/data/item/ashearas-clasp",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_009_1xx_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Asheara's Iron Fist"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/frostburn",
-    "url_name": "frostburn",
-    "api_url": "https://us.battle.net/api/d3/data/item/frostburn",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_002_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "legendary",
-    "name": "Frostburn"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/tasker-and-theo",
-    "url_name": "tasker-and-theo",
-    "api_url": "https://us.battle.net/api/d3/data/item/tasker-and-theo",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_003_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "legendary",
-    "name": "Tasker and Theo"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/immortal-kings-irons",
-    "url_name": "immortal-kings-irons",
-    "api_url": "https://us.battle.net/api/d3/data/item/immortal-kings-irons",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_008_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Immortal King's Irons"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/innas-hold",
-    "url_name": "innas-hold",
-    "api_url": "https://us.battle.net/api/d3/data/item/innas-hold",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_gloves_04_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Inna's Hold"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/natalyas-touch",
-    "url_name": "natalyas-touch",
-    "api_url": "https://us.battle.net/api/d3/data/item/natalyas-touch",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_gloves_01_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Natalya's Touch"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/tal-rashas-grasp",
-    "url_name": "tal-rashas-grasp",
-    "api_url": "https://us.battle.net/api/d3/data/item/tal-rashas-grasp",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_gloves_02_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Tal Rasha's Grasp"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/zunimassas-finger-wraps",
-    "url_name": "zunimassas-finger-wraps",
-    "api_url": "https://us.battle.net/api/d3/data/item/zunimassas-finger-wraps",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_gloves_03_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Zunimassa's Finger Wraps"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/sages-grasp",
-    "url_name": "sages-grasp",
-    "api_url": "https://us.battle.net/api/d3/data/item/sages-grasp",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_017_1xx_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Sage's Gesture"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/penders-purchase",
-    "url_name": "penders-purchase",
-    "api_url": "https://us.battle.net/api/d3/data/item/penders-purchase",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_001_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "legendary",
-    "name": "Penders Purchase"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/arachyrs-claws",
-    "url_name": "arachyrs-claws",
-    "api_url": "https://us.battle.net/api/d3/data/item/arachyrs-claws",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_02_p3_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Arachyr’s Claws"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/ashearas-ward",
-    "url_name": "ashearas-ward",
-    "api_url": "https://us.battle.net/api/d3/data/item/ashearas-ward",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_009_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Asheara's Ward"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/cains-scriviner",
-    "url_name": "cains-scriviner",
-    "api_url": "https://us.battle.net/api/d3/data/item/cains-scriviner",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_015_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Cain's Scrivener"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/fiendish-grips",
-    "url_name": "fiendish-grips",
-    "api_url": "https://us.battle.net/api/d3/data/item/fiendish-grips",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_03_p2_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Fiendish Grips"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/fierce-gauntlets",
-    "url_name": "fierce-gauntlets",
-    "api_url": "https://us.battle.net/api/d3/data/item/fierce-gauntlets",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_02_p2_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Fierce Gauntlets"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/firebirds-talons",
-    "url_name": "firebirds-talons",
-    "api_url": "https://us.battle.net/api/d3/data/item/firebirds-talons",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_06_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Firebird's Talons"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/fists-of-thunder",
-    "url_name": "fists-of-thunder",
-    "api_url": "https://us.battle.net/api/d3/data/item/fists-of-thunder",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_08_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Fists of Thunder"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/gauntlet-of-the-wastes",
-    "url_name": "gauntlet-of-the-wastes",
-    "api_url": "https://us.battle.net/api/d3/data/item/gauntlet-of-the-wastes",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_01_p2_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Gauntlet of the Wastes"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/gauntlets-of-akkhan",
-    "url_name": "gauntlets-of-akkhan",
-    "api_url": "https://us.battle.net/api/d3/data/item/gauntlets-of-akkhan",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_10_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Gauntlets of Akkhan"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/helltooth-gauntlets",
-    "url_name": "helltooth-gauntlets",
-    "api_url": "https://us.battle.net/api/d3/data/item/helltooth-gauntlets",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_16_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Helltooth Gauntlets"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/jade-harvesters-mercy",
-    "url_name": "jade-harvesters-mercy",
-    "api_url": "https://us.battle.net/api/d3/data/item/jade-harvesters-mercy",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_09_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Jade Harvester's Mercy"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/marauders-gloves",
-    "url_name": "marauders-gloves",
-    "api_url": "https://us.battle.net/api/d3/data/item/marauders-gloves",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_07_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Marauder's Gloves"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/pride-of-the-invoker",
-    "url_name": "pride-of-the-invoker",
-    "api_url": "https://us.battle.net/api/d3/data/item/pride-of-the-invoker",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_12_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Pride of the Invoker"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/pull-of-the-earth",
-    "url_name": "pull-of-the-earth",
-    "api_url": "https://us.battle.net/api/d3/data/item/pull-of-the-earth",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_15_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Pull of the Earth"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/raekors-wraps",
-    "url_name": "raekors-wraps",
-    "api_url": "https://us.battle.net/api/d3/data/item/raekors-wraps",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_05_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Raekor's Wraps"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/rolands-grasp",
-    "url_name": "rolands-grasp",
-    "api_url": "https://us.battle.net/api/d3/data/item/rolands-grasp",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_01_p1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Roland's Grasp"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/sages-purchase",
-    "url_name": "sages-purchase",
-    "api_url": "https://us.battle.net/api/d3/data/item/sages-purchase",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_017_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Sage's Purchase"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/sunwukos-paws",
-    "url_name": "sunwukos-paws",
-    "api_url": "https://us.battle.net/api/d3/data/item/sunwukos-paws",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_11_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Sunwuko's Paws"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-shadows-grasp",
-    "url_name": "the-shadows-grasp",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-shadows-grasp",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_14_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "The Shadow's Grasp"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/ulianas-fury",
-    "url_name": "ulianas-fury",
-    "api_url": "https://us.battle.net/api/d3/data/item/ulianas-fury",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_01_p3_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Uliana's Fury"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/vyrs-grasping-gauntlets",
-    "url_name": "vyrs-grasping-gauntlets",
-    "api_url": "https://us.battle.net/api/d3/data/item/vyrs-grasping-gauntlets",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_13_x1_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Vyr's Grasping Gauntlets"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/will-of-the-light",
-    "url_name": "will-of-the-light",
-    "api_url": "https://us.battle.net/api/d3/data/item/will-of-the-light",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_03_p3_demonhunter_male.png",
-    "type": "gloves",
-    "quality": "set",
-    "name": "Will of the Light"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/goldwrap",
-    "url_name": "goldwrap",
-    "api_url": "https://us.battle.net/api/d3/data/item/goldwrap",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_010_x1_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Goldwrap"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/vigilante-belt",
-    "url_name": "vigilante-belt",
-    "api_url": "https://us.battle.net/api/d3/data/item/vigilante-belt",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_002_x1_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Vigilante Belt"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/insatiable-belt",
-    "url_name": "insatiable-belt",
-    "api_url": "https://us.battle.net/api/d3/data/item/insatiable-belt",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_103_x1_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Insatiable Belt"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/binding-of-the-lost",
-    "url_name": "binding-of-the-lost",
-    "api_url": "https://us.battle.net/api/d3/data/item/binding-of-the-lost",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_belt_03_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Binding of the Lost"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-shame-of-delsere",
-    "url_name": "the-shame-of-delsere",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-shame-of-delsere",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_belt_02_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "The Shame of Delsere"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/kyoshiros-soul",
-    "url_name": "kyoshiros-soul",
-    "api_url": "https://us.battle.net/api/d3/data/item/kyoshiros-soul",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_belt_05_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Kyoshiro's Soul"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/sacred-harness",
-    "url_name": "sacred-harness",
-    "api_url": "https://us.battle.net/api/d3/data/item/sacred-harness",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_belt_01_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Sacred Harness"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/quick-draw-belt",
-    "url_name": "quick-draw-belt",
-    "api_url": "https://us.battle.net/api/d3/data/item/quick-draw-belt",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_004_1xx_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Quick Draw Belt"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/saffron-wrap",
-    "url_name": "saffron-wrap",
-    "api_url": "https://us.battle.net/api/d3/data/item/saffron-wrap",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_001_x1_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Saffron Wrap"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/string-of-ears",
-    "url_name": "string-of-ears",
-    "api_url": "https://us.battle.net/api/d3/data/item/string-of-ears",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_belt_03_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "String of Ears"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/fazulas-improbable-chain",
-    "url_name": "fazulas-improbable-chain",
-    "api_url": "https://us.battle.net/api/d3/data/item/fazulas-improbable-chain",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_belt_07_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Fazula’s Improbable Chain"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/hergbrashs-binding",
-    "url_name": "hergbrashs-binding",
-    "api_url": "https://us.battle.net/api/d3/data/item/hergbrashs-binding",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_belt_06_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Hergbrash’s Binding"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/captain-crimsons-brace",
-    "url_name": "captain-crimsons-brace",
-    "api_url": "https://us.battle.net/api/d3/data/item/captain-crimsons-brace",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_012_1xx_demonhunter_male.png",
-    "type": "belt",
-    "quality": "set",
-    "name": "Captain Crimson's Satin Sash"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/belt-of-transcendence",
-    "url_name": "belt-of-transcendence",
-    "api_url": "https://us.battle.net/api/d3/data/item/belt-of-transcendence",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_belt_02_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Belt of Transcendence"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/blessed-of-haull",
-    "url_name": "blessed-of-haull",
-    "api_url": "https://us.battle.net/api/d3/data/item/blessed-of-haull",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_belt_05_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Blessed of Haull"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/chain-of-shadows",
-    "url_name": "chain-of-shadows",
-    "api_url": "https://us.battle.net/api/d3/data/item/chain-of-shadows",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_belt_01_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Chain of Shadows"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/cord-of-the-sherma",
-    "url_name": "cord-of-the-sherma",
-    "api_url": "https://us.battle.net/api/d3/data/item/cord-of-the-sherma",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_104_p2_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Cord of the Sherma"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/crashing-rain",
-    "url_name": "crashing-rain",
-    "api_url": "https://us.battle.net/api/d3/data/item/crashing-rain",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_belt_01_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Crashing Rain"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/harrington-waistguard",
-    "url_name": "harrington-waistguard",
-    "api_url": "https://us.battle.net/api/d3/data/item/harrington-waistguard",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_105_x1_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Harrington Waistguard"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/haunting-girdle",
-    "url_name": "haunting-girdle",
-    "api_url": "https://us.battle.net/api/d3/data/item/haunting-girdle",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_belt_03_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Haunting Girdle"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/hwoj-wrap",
-    "url_name": "hwoj-wrap",
-    "api_url": "https://us.battle.net/api/d3/data/item/hwoj-wrap",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_107_x1_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Hwoj Wrap"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/omnislash",
-    "url_name": "omnislash",
-    "api_url": "https://us.battle.net/api/d3/data/item/omnislash",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_belt_04_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Omnislash"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/omryns-chain",
-    "url_name": "omryns-chain",
-    "api_url": "https://us.battle.net/api/d3/data/item/omryns-chain",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_belt_06_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Omryn's Chain"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/razor-strop",
-    "url_name": "razor-strop",
-    "api_url": "https://us.battle.net/api/d3/data/item/razor-strop",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_101_x1_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Razor Strop"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/sash-of-knives",
-    "url_name": "sash-of-knives",
-    "api_url": "https://us.battle.net/api/d3/data/item/sash-of-knives",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_102_p2_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Sash of Knives"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/sebors-nightmare",
-    "url_name": "sebors-nightmare",
-    "api_url": "https://us.battle.net/api/d3/data/item/sebors-nightmare",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_108_p2_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Sebor's Nightmare"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/angel-hair-braid",
-    "url_name": "angel-hair-braid",
-    "api_url": "https://us.battle.net/api/d3/data/item/angel-hair-braid",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_003_p1_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Angel Hair Braid"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/thundergods-vigor",
-    "url_name": "thundergods-vigor",
-    "api_url": "https://us.battle.net/api/d3/data/item/thundergods-vigor",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_barbbelt_003_x1_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Thundergod's Vigor"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/guardians-scabbard",
-    "url_name": "guardians-scabbard",
-    "api_url": "https://us.battle.net/api/d3/data/item/guardians-scabbard",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_013_1xx_demonhunter_male.png",
-    "type": "belt",
-    "quality": "set",
-    "name": "Guardian's Sheath"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/belt-of-the-trove",
-    "url_name": "belt-of-the-trove",
-    "api_url": "https://us.battle.net/api/d3/data/item/belt-of-the-trove",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_belt_008_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Belt of the Trove"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/hellcat-waistguard",
-    "url_name": "hellcat-waistguard",
-    "api_url": "https://us.battle.net/api/d3/data/item/hellcat-waistguard",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_005_x1_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Hellcat Waistguard"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-witching-hour",
-    "url_name": "the-witching-hour",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-witching-hour",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_009_x1_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "The Witching Hour"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/blackthornes-notched-belt",
-    "url_name": "blackthornes-notched-belt",
-    "api_url": "https://us.battle.net/api/d3/data/item/blackthornes-notched-belt",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_015_x1_demonhunter_male.png",
-    "type": "belt",
-    "quality": "set",
-    "name": "Blackthorne's Notched Belt"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/innas-favor",
-    "url_name": "innas-favor",
-    "api_url": "https://us.battle.net/api/d3/data/item/innas-favor",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_007_x1_demonhunter_male.png",
-    "type": "belt",
-    "quality": "set",
-    "name": "Inna's Favor"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/tal-rashas-brace",
-    "url_name": "tal-rashas-brace",
-    "api_url": "https://us.battle.net/api/d3/data/item/tal-rashas-brace",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_006_x1_demonhunter_male.png",
-    "type": "belt",
-    "quality": "set",
-    "name": "Tal Rasha's Brace"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demons-binding",
-    "url_name": "demons-binding",
-    "api_url": "https://us.battle.net/api/d3/data/item/demons-binding",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_014_1xx_demonhunter_male.png",
-    "type": "belt",
-    "quality": "set",
-    "name": "Demon's Lock"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/jangs-envelopment",
-    "url_name": "jangs-envelopment",
-    "api_url": "https://us.battle.net/api/d3/data/item/jangs-envelopment",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_106_x1_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Jang's Envelopment"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/fleeting-strap",
-    "url_name": "fleeting-strap",
-    "api_url": "https://us.battle.net/api/d3/data/item/fleeting-strap",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_004_x1_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Fleeting Strap"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/hunters-wrath",
-    "url_name": "hunters-wrath",
-    "api_url": "https://us.battle.net/api/d3/data/item/hunters-wrath",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_belt_005_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Hunter's Wrath"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/zoeys-secret",
-    "url_name": "zoeys-secret",
-    "api_url": "https://us.battle.net/api/d3/data/item/zoeys-secret",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_belt_04_demonhunter_male.png",
-    "type": "belt",
-    "quality": "legendary",
-    "name": "Zoey's Secret"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/captain-crimsons-silk-girdle",
-    "url_name": "captain-crimsons-silk-girdle",
-    "api_url": "https://us.battle.net/api/d3/data/item/captain-crimsons-silk-girdle",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_012_x1_demonhunter_male.png",
-    "type": "belt",
-    "quality": "set",
-    "name": "Captain Crimson's Silk Girdle"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demons-restraint",
-    "url_name": "demons-restraint",
-    "api_url": "https://us.battle.net/api/d3/data/item/demons-restraint",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_014_x1_demonhunter_male.png",
-    "type": "belt",
-    "quality": "set",
-    "name": "Demon's Restraint"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/guardians-case",
-    "url_name": "guardians-case",
-    "api_url": "https://us.battle.net/api/d3/data/item/guardians-case",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_013_x1_demonhunter_male.png",
-    "type": "belt",
-    "quality": "set",
-    "name": "Guardian's Case"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/krelms-buff-belt",
-    "url_name": "krelms-buff-belt",
-    "api_url": "https://us.battle.net/api/d3/data/item/krelms-buff-belt",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_set_02_x1_demonhunter_male.png",
-    "type": "belt",
-    "quality": "set",
-    "name": "Krelm's Buff Belt"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/girdle-of-giants",
-    "url_name": "girdle-of-giants",
-    "api_url": "https://us.battle.net/api/d3/data/item/girdle-of-giants",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_barbbelt_004_x1_demonhunter_male.png",
-    "type": "mighty-belt",
-    "quality": "legendary",
-    "name": "Girdle of Giants"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-undisputed-champion",
-    "url_name": "the-undisputed-champion",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-undisputed-champion",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_barbbelt_006_demonhunter_male.png",
-    "type": "mighty-belt",
-    "quality": "legendary",
-    "name": "The Undisputed Champion"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/kotuurs-brace",
-    "url_name": "kotuurs-brace",
-    "api_url": "https://us.battle.net/api/d3/data/item/kotuurs-brace",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_barbbelt_007_x1_demonhunter_male.png",
-    "type": "mighty-belt",
-    "quality": "legendary",
-    "name": "Kotuur's Brace"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/pride-of-cassius",
-    "url_name": "pride-of-cassius",
-    "api_url": "https://us.battle.net/api/d3/data/item/pride-of-cassius",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_barbbelt_002_x1_demonhunter_male.png",
-    "type": "mighty-belt",
-    "quality": "legendary",
-    "name": "Pride of Cassius"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/chilaniks-chain",
-    "url_name": "chilaniks-chain",
-    "api_url": "https://us.battle.net/api/d3/data/item/chilaniks-chain",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_barbbelt_101_x1_demonhunter_male.png",
-    "type": "mighty-belt",
-    "quality": "legendary",
-    "name": "Chilanik's Chain"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/lamentation",
-    "url_name": "lamentation",
-    "api_url": "https://us.battle.net/api/d3/data/item/lamentation",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_barbbelt_005_p1_demonhunter_male.png",
-    "type": "mighty-belt",
-    "quality": "legendary",
-    "name": "Lamentation"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/immortal-kings-tribal-binding",
-    "url_name": "immortal-kings-tribal-binding",
-    "api_url": "https://us.battle.net/api/d3/data/item/immortal-kings-tribal-binding",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_barbbelt_009_x1_demonhunter_male.png",
-    "type": "mighty-belt",
-    "quality": "set",
-    "name": "Immortal King's Tribal Binding"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/dread-iron",
-    "url_name": "dread-iron",
-    "api_url": "https://us.battle.net/api/d3/data/item/dread-iron",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_barbbelt_001_demonhunter_male.png",
-    "type": "mighty-belt",
-    "quality": "legendary",
-    "name": "Dread Iron"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/pox-faulds",
-    "url_name": "pox-faulds",
-    "api_url": "https://us.battle.net/api/d3/data/item/pox-faulds",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_007_p2_demonhunter_male.png",
-    "type": "pants",
-    "quality": "legendary",
-    "name": "Pox Faulds"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/deaths-bargain",
-    "url_name": "deaths-bargain",
-    "api_url": "https://us.battle.net/api/d3/data/item/deaths-bargain",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_102_x1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "legendary",
-    "name": "Death's Bargain"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/cains-raiment",
-    "url_name": "cains-raiment",
-    "api_url": "https://us.battle.net/api/d3/data/item/cains-raiment",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_010_1xx_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Cain's Robes"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/hammer-jammers",
-    "url_name": "hammer-jammers",
-    "api_url": "https://us.battle.net/api/d3/data/item/hammer-jammers",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_pants_002_demonhunter_male.png",
-    "type": "pants",
-    "quality": "legendary",
-    "name": "Hammer Jammers"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/captain-crimsons-codpiece",
-    "url_name": "captain-crimsons-codpiece",
-    "api_url": "https://us.battle.net/api/d3/data/item/captain-crimsons-codpiece",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_012_1xx_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Captain Crimson's Bowsprit"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/hexing-pants-of-mr-yan",
-    "url_name": "hexing-pants-of-mr-yan",
-    "api_url": "https://us.battle.net/api/d3/data/item/hexing-pants-of-mr-yan",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_101_x1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "legendary",
-    "name": "Hexing Pants of Mr. Yan"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/swamp-land-waders",
-    "url_name": "swamp-land-waders",
-    "api_url": "https://us.battle.net/api/d3/data/item/swamp-land-waders",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_001_x1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "legendary",
-    "name": "Swamp Land Waders"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/ashearas-cradle",
-    "url_name": "ashearas-cradle",
-    "api_url": "https://us.battle.net/api/d3/data/item/ashearas-cradle",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_009_1xx_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Asheara's Gait"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/depth-diggers",
-    "url_name": "depth-diggers",
-    "api_url": "https://us.battle.net/api/d3/data/item/depth-diggers",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_006_p1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "legendary",
-    "name": "Depth Diggers"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/blackthornes-jousting-mail",
-    "url_name": "blackthornes-jousting-mail",
-    "api_url": "https://us.battle.net/api/d3/data/item/blackthornes-jousting-mail",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_013_x1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Blackthorne's Jousting Mail"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/immortal-kings-stature",
-    "url_name": "immortal-kings-stature",
-    "api_url": "https://us.battle.net/api/d3/data/item/immortal-kings-stature",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_pants_02_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Immortal King's Stature"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/innas-temperance",
-    "url_name": "innas-temperance",
-    "api_url": "https://us.battle.net/api/d3/data/item/innas-temperance",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_008_x1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Inna's Temperance"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/natalyas-leggings",
-    "url_name": "natalyas-leggings",
-    "api_url": "https://us.battle.net/api/d3/data/item/natalyas-leggings",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_pants_01_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Natalya's Leggings"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/tal-rashas-stride",
-    "url_name": "tal-rashas-stride",
-    "api_url": "https://us.battle.net/api/d3/data/item/tal-rashas-stride",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_pants_03_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Tal Rasha's Stride"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/zunimassas-cloth",
-    "url_name": "zunimassas-cloth",
-    "api_url": "https://us.battle.net/api/d3/data/item/zunimassas-cloth",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_pants_04_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Zunimassa's Cloth"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/gehennas",
-    "url_name": "gehennas",
-    "api_url": "https://us.battle.net/api/d3/data/item/gehennas",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_005_1xx_demonhunter_male.png",
-    "type": "pants",
-    "quality": "legendary",
-    "name": "Gehennas"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demons-flesh",
-    "url_name": "demons-flesh",
-    "api_url": "https://us.battle.net/api/d3/data/item/demons-flesh",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_014_1xx_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Demon's Scale"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/skelons-deceit",
-    "url_name": "skelons-deceit",
-    "api_url": "https://us.battle.net/api/d3/data/item/skelons-deceit",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_005_x1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "legendary",
-    "name": "Skelon's Deceit"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/arachyrs-legs",
-    "url_name": "arachyrs-legs",
-    "api_url": "https://us.battle.net/api/d3/data/item/arachyrs-legs",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_02_p3_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Arachyr’s Legs"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/ashearas-pace",
-    "url_name": "ashearas-pace",
-    "api_url": "https://us.battle.net/api/d3/data/item/ashearas-pace",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_009_x1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Asheara's Pace"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/cains-habit",
-    "url_name": "cains-habit",
-    "api_url": "https://us.battle.net/api/d3/data/item/cains-habit",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_010_x1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Cain's Habit"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/captain-crimsons-thrust",
-    "url_name": "captain-crimsons-thrust",
-    "api_url": "https://us.battle.net/api/d3/data/item/captain-crimsons-thrust",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_012_x1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Captain Crimson's Thrust"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/cuisses-of-akkhan",
-    "url_name": "cuisses-of-akkhan",
-    "api_url": "https://us.battle.net/api/d3/data/item/cuisses-of-akkhan",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_10_x1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Cuisses of Akkhan"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demons-plate",
-    "url_name": "demons-plate",
-    "api_url": "https://us.battle.net/api/d3/data/item/demons-plate",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_014_x1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Demon's Plate"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/firebirds-down",
-    "url_name": "firebirds-down",
-    "api_url": "https://us.battle.net/api/d3/data/item/firebirds-down",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_06_x1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Firebird's Down"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/helltooth-leg-guards",
-    "url_name": "helltooth-leg-guards",
-    "api_url": "https://us.battle.net/api/d3/data/item/helltooth-leg-guards",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_16_x1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Helltooth Leg Guards"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/jade-harvesters-courage",
-    "url_name": "jade-harvesters-courage",
-    "api_url": "https://us.battle.net/api/d3/data/item/jade-harvesters-courage",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_09_x1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Jade Harvester's Courage"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/leg-guards-of-mystery",
-    "url_name": "leg-guards-of-mystery",
-    "api_url": "https://us.battle.net/api/d3/data/item/leg-guards-of-mystery",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_02_p2_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Leg Guards of Mystery"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/marauders-encasement",
-    "url_name": "marauders-encasement",
-    "api_url": "https://us.battle.net/api/d3/data/item/marauders-encasement",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_07_x1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Marauder's Encasement"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/raekors-breeches",
-    "url_name": "raekors-breeches",
-    "api_url": "https://us.battle.net/api/d3/data/item/raekors-breeches",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_05_x1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Raekor's Breeches"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/renewal-of-the-invoker",
-    "url_name": "renewal-of-the-invoker",
-    "api_url": "https://us.battle.net/api/d3/data/item/renewal-of-the-invoker",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_12_x1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Renewal of the Invoker"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/rolands-determination",
-    "url_name": "rolands-determination",
-    "api_url": "https://us.battle.net/api/d3/data/item/rolands-determination",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_01_p1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Roland's Determination"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/scales-of-the-dancing-serpent",
-    "url_name": "scales-of-the-dancing-serpent",
-    "api_url": "https://us.battle.net/api/d3/data/item/scales-of-the-dancing-serpent",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_08_x1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Scales of the Dancing Serpent"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/sunwukos-leggings",
-    "url_name": "sunwukos-leggings",
-    "api_url": "https://us.battle.net/api/d3/data/item/sunwukos-leggings",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_11_x1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Sunwuko's Leggings"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/tasset-of-the-wastes",
-    "url_name": "tasset-of-the-wastes",
-    "api_url": "https://us.battle.net/api/d3/data/item/tasset-of-the-wastes",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_01_p2_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Tasset of the Wastes"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-shadows-coil",
-    "url_name": "the-shadows-coil",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-shadows-coil",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_14_x1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "The Shadow's Coil"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/towers-of-the-light",
-    "url_name": "towers-of-the-light",
-    "api_url": "https://us.battle.net/api/d3/data/item/towers-of-the-light",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_03_p3_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Towers of the Light"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/ulianas-burden",
-    "url_name": "ulianas-burden",
-    "api_url": "https://us.battle.net/api/d3/data/item/ulianas-burden",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_01_p3_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Uliana's Burden"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/unholy-plates",
-    "url_name": "unholy-plates",
-    "api_url": "https://us.battle.net/api/d3/data/item/unholy-plates",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_03_p2_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Unholy Plates"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/vyrs-fantastic-finery",
-    "url_name": "vyrs-fantastic-finery",
-    "api_url": "https://us.battle.net/api/d3/data/item/vyrs-fantastic-finery",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_13_x1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Vyr's Fantastic Finery"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/weight-of-the-earth",
-    "url_name": "weight-of-the-earth",
-    "api_url": "https://us.battle.net/api/d3/data/item/weight-of-the-earth",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_15_x1_demonhunter_male.png",
-    "type": "pants",
-    "quality": "set",
-    "name": "Weight of the Earth"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/lut-socks",
-    "url_name": "lut-socks",
-    "api_url": "https://us.battle.net/api/d3/data/item/lut-socks",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_009_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "legendary",
-    "name": "Lut Socks"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/rivera-dancers",
-    "url_name": "rivera-dancers",
-    "api_url": "https://us.battle.net/api/d3/data/item/rivera-dancers",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_boots_001_demonhunter_male.png",
-    "type": "boots",
-    "quality": "legendary",
-    "name": "Rivera Dancers"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-crudest-boots",
-    "url_name": "the-crudest-boots",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-crudest-boots",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p1_unique_boots_010_demonhunter_male.png",
-    "type": "boots",
-    "quality": "legendary",
-    "name": "The Crudest Boots"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/boots-of-disregard",
-    "url_name": "boots-of-disregard",
-    "api_url": "https://us.battle.net/api/d3/data/item/boots-of-disregard",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_102_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "legendary",
-    "name": "Boots of Disregard"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/illusory-boots",
-    "url_name": "illusory-boots",
-    "api_url": "https://us.battle.net/api/d3/data/item/illusory-boots",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_103_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "legendary",
-    "name": "Illusory Boots"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/cains-slippers",
-    "url_name": "cains-slippers",
-    "api_url": "https://us.battle.net/api/d3/data/item/cains-slippers",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_015_1xx_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Cain's Sandals"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/captain-crimsons-deck-boots",
-    "url_name": "captain-crimsons-deck-boots",
-    "api_url": "https://us.battle.net/api/d3/data/item/captain-crimsons-deck-boots",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_017_1xx_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Captain Crimson's Whalers"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/irontoe-mudsputters",
-    "url_name": "irontoe-mudsputters",
-    "api_url": "https://us.battle.net/api/d3/data/item/irontoe-mudsputters",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_104_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "legendary",
-    "name": "Irontoe Mudsputters"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/fire-walkers",
-    "url_name": "fire-walkers",
-    "api_url": "https://us.battle.net/api/d3/data/item/fire-walkers",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_007_p2_demonhunter_male.png",
-    "type": "boots",
-    "quality": "legendary",
-    "name": "Fire Walkers"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/lost-boys",
-    "url_name": "lost-boys",
-    "api_url": "https://us.battle.net/api/d3/data/item/lost-boys",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_005_1xx_demonhunter_male.png",
-    "type": "boots",
-    "quality": "legendary",
-    "name": "Lost Boys"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/ashearas-lock",
-    "url_name": "ashearas-lock",
-    "api_url": "https://us.battle.net/api/d3/data/item/ashearas-lock",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_014_1xx_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Asheara's Tracks"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/ice-climbers",
-    "url_name": "ice-climbers",
-    "api_url": "https://us.battle.net/api/d3/data/item/ice-climbers",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_008_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "legendary",
-    "name": "Ice Climbers"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/nilfurs-boast",
-    "url_name": "nilfurs-boast",
-    "api_url": "https://us.battle.net/api/d3/data/item/nilfurs-boast",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_boots_01_demonhunter_male.png",
-    "type": "boots",
-    "quality": "legendary",
-    "name": "Nilfur's Boast"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/blackthornes-spurs",
-    "url_name": "blackthornes-spurs",
-    "api_url": "https://us.battle.net/api/d3/data/item/blackthornes-spurs",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_019_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Blackthorne's Spurs"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/immortal-kings-stride",
-    "url_name": "immortal-kings-stride",
-    "api_url": "https://us.battle.net/api/d3/data/item/immortal-kings-stride",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_012_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Immortal King's Stride"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/innas-sandals",
-    "url_name": "innas-sandals",
-    "api_url": "https://us.battle.net/api/d3/data/item/innas-sandals",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_boots_02_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Inna's Sandals"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/natalyas-bloody-footprints",
-    "url_name": "natalyas-bloody-footprints",
-    "api_url": "https://us.battle.net/api/d3/data/item/natalyas-bloody-footprints",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_011_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Natalya's Bloody Footprints"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/zunimassas-trail",
-    "url_name": "zunimassas-trail",
-    "api_url": "https://us.battle.net/api/d3/data/item/zunimassas-trail",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_013_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Zunimassa's Trail"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/sages-seekers",
-    "url_name": "sages-seekers",
-    "api_url": "https://us.battle.net/api/d3/data/item/sages-seekers",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_018_1xx_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Sage's Journey"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/board-walkers",
-    "url_name": "board-walkers",
-    "api_url": "https://us.battle.net/api/d3/data/item/board-walkers",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_005_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "legendary",
-    "name": "Board Walkers"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/arachyrs-stride",
-    "url_name": "arachyrs-stride",
-    "api_url": "https://us.battle.net/api/d3/data/item/arachyrs-stride",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_02_p3_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Arachyr’s Stride"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/ashearas-finders",
-    "url_name": "ashearas-finders",
-    "api_url": "https://us.battle.net/api/d3/data/item/ashearas-finders",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_014_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Asheara's Finders"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/cains-travelers",
-    "url_name": "cains-travelers",
-    "api_url": "https://us.battle.net/api/d3/data/item/cains-travelers",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_015_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Cain's Travelers"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/captain-crimsons-waders",
-    "url_name": "captain-crimsons-waders",
-    "api_url": "https://us.battle.net/api/d3/data/item/captain-crimsons-waders",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_017_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Captain Crimson's Waders"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/eightdemon-boots",
-    "url_name": "eightdemon-boots",
-    "api_url": "https://us.battle.net/api/d3/data/item/eightdemon-boots",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_08_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Eight-Demon Boots"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/firebirds-tarsi",
-    "url_name": "firebirds-tarsi",
-    "api_url": "https://us.battle.net/api/d3/data/item/firebirds-tarsi",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_06_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Firebird's Tarsi"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/foundation-of-the-earth",
-    "url_name": "foundation-of-the-earth",
-    "api_url": "https://us.battle.net/api/d3/data/item/foundation-of-the-earth",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_15_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Foundation of the Earth"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/foundation-of-the-light",
-    "url_name": "foundation-of-the-light",
-    "api_url": "https://us.battle.net/api/d3/data/item/foundation-of-the-light",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_03_p3_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Foundation of the Light"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/hell-walkers",
-    "url_name": "hell-walkers",
-    "api_url": "https://us.battle.net/api/d3/data/item/hell-walkers",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_03_p2_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Hell Walkers"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/helltooth-greaves",
-    "url_name": "helltooth-greaves",
-    "api_url": "https://us.battle.net/api/d3/data/item/helltooth-greaves",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_16_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Helltooth Greaves"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/jade-harvesters-swiftness",
-    "url_name": "jade-harvesters-swiftness",
-    "api_url": "https://us.battle.net/api/d3/data/item/jade-harvesters-swiftness",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_09_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Jade Harvester's Swiftness"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/marauders-treads",
-    "url_name": "marauders-treads",
-    "api_url": "https://us.battle.net/api/d3/data/item/marauders-treads",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_07_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Marauder's Treads"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/raekors-striders",
-    "url_name": "raekors-striders",
-    "api_url": "https://us.battle.net/api/d3/data/item/raekors-striders",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_05_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Raekor's Striders"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/rolands-stride",
-    "url_name": "rolands-stride",
-    "api_url": "https://us.battle.net/api/d3/data/item/rolands-stride",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_01_p1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Roland's Stride"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/sabaton-of-the-wastes",
-    "url_name": "sabaton-of-the-wastes",
-    "api_url": "https://us.battle.net/api/d3/data/item/sabaton-of-the-wastes",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_01_p2_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Sabaton of the Wastes"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/sabatons-of-akkhan",
-    "url_name": "sabatons-of-akkhan",
-    "api_url": "https://us.battle.net/api/d3/data/item/sabatons-of-akkhan",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_10_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Sabatons of Akkhan"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/sages-passage",
-    "url_name": "sages-passage",
-    "api_url": "https://us.battle.net/api/d3/data/item/sages-passage",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_018_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Sage's Passage"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/striders-of-destiny",
-    "url_name": "striders-of-destiny",
-    "api_url": "https://us.battle.net/api/d3/data/item/striders-of-destiny",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_02_p2_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Striders of Destiny"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-shadows-heels",
-    "url_name": "the-shadows-heels",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-shadows-heels",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_14_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "The Shadow's Heels"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/ulianas-destiny",
-    "url_name": "ulianas-destiny",
-    "api_url": "https://us.battle.net/api/d3/data/item/ulianas-destiny",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_01_p3_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Uliana's Destiny"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/vyrs-swaggering-stance",
-    "url_name": "vyrs-swaggering-stance",
-    "api_url": "https://us.battle.net/api/d3/data/item/vyrs-swaggering-stance",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_13_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Vyr's Swaggering Stance"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/zeal-of-the-invoker",
-    "url_name": "zeal-of-the-invoker",
-    "api_url": "https://us.battle.net/api/d3/data/item/zeal-of-the-invoker",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_12_x1_demonhunter_male.png",
-    "type": "boots",
-    "quality": "set",
-    "name": "Zeal of the Invoker"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/jeweler/recipe/hellfire-amulet-of-strength",
-    "url_name": "hellfire-amulet-of-strength",
-    "api_url": "https://us.battle.net/api/d3/data/item/hellfire-amulet-of-strength",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/x1_amulet_norm_unique_25_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "Hellfire Amulet"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/jeweler/recipe/hellfire-amulet-of-intelligence",
-    "url_name": "hellfire-amulet-of-intelligence",
-    "api_url": "https://us.battle.net/api/d3/data/item/hellfire-amulet-of-intelligence",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/x1_amulet_norm_unique_25_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "Hellfire Amulet"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/jeweler/recipe/hellfire-amulet-of-dexterity",
-    "url_name": "hellfire-amulet-of-dexterity",
-    "api_url": "https://us.battle.net/api/d3/data/item/hellfire-amulet-of-dexterity",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/x1_amulet_norm_unique_25_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "Hellfire Amulet"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/moonlight-ward",
-    "url_name": "moonlight-ward",
-    "api_url": "https://us.battle.net/api/d3/data/item/moonlight-ward",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_003_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "Moonlight Ward"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/squirts-necklace",
-    "url_name": "squirts-necklace",
-    "api_url": "https://us.battle.net/api/d3/data/item/squirts-necklace",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_010_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "Squirt's Necklace"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/golden-gorget-of-leoric",
-    "url_name": "golden-gorget-of-leoric",
-    "api_url": "https://us.battle.net/api/d3/data/item/golden-gorget-of-leoric",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_105_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "Golden Gorget of Leoric"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/overwhelming-desire",
-    "url_name": "overwhelming-desire",
-    "api_url": "https://us.battle.net/api/d3/data/item/overwhelming-desire",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_106_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "Overwhelming Desire"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/eye-of-etlich",
-    "url_name": "eye-of-etlich",
-    "api_url": "https://us.battle.net/api/d3/data/item/eye-of-etlich",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_014_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "Eye of Etlich"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/rondals-locket",
-    "url_name": "rondals-locket",
-    "api_url": "https://us.battle.net/api/d3/data/item/rondals-locket",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_009_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "Rondal's Locket"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/talisman-of-aranoch",
-    "url_name": "talisman-of-aranoch",
-    "api_url": "https://us.battle.net/api/d3/data/item/talisman-of-aranoch",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_012_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "Talisman of Aranoch"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/ancestors-grace",
-    "url_name": "ancestors-grace",
-    "api_url": "https://us.battle.net/api/d3/data/item/ancestors-grace",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_102_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "Ancestors' Grace"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/countess-julias-cameo",
-    "url_name": "countess-julias-cameo",
-    "api_url": "https://us.battle.net/api/d3/data/item/countess-julias-cameo",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_103_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "Countess Julia's Cameo"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/dovu-energy-trap",
-    "url_name": "dovu-energy-trap",
-    "api_url": "https://us.battle.net/api/d3/data/item/dovu-energy-trap",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_107_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "Dovu Energy Trap"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/haunt-of-vaxo",
-    "url_name": "haunt-of-vaxo",
-    "api_url": "https://us.battle.net/api/d3/data/item/haunt-of-vaxo",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_101_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "Haunt of Vaxo"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/rakoffs-glass-of-life",
-    "url_name": "rakoffs-glass-of-life",
-    "api_url": "https://us.battle.net/api/d3/data/item/rakoffs-glass-of-life",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_108_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "Rakoff's Glass of Life"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-ess-of-johan",
-    "url_name": "the-ess-of-johan",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-ess-of-johan",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_104_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "The Ess of Johan"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/holy-beacon",
-    "url_name": "holy-beacon",
-    "api_url": "https://us.battle.net/api/d3/data/item/holy-beacon",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_013_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "Holy Beacon"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/kymbos-gold",
-    "url_name": "kymbos-gold",
-    "api_url": "https://us.battle.net/api/d3/data/item/kymbos-gold",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_002_p1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "Kymbo's Gold"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-flavor-of-time",
-    "url_name": "the-flavor-of-time",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-flavor-of-time",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_001_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "The Flavor of Time"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/maras-kaleidoscope",
-    "url_name": "maras-kaleidoscope",
-    "api_url": "https://us.battle.net/api/d3/data/item/maras-kaleidoscope",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_015_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "Mara's Kaleidoscope"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/ouroboros",
-    "url_name": "ouroboros",
-    "api_url": "https://us.battle.net/api/d3/data/item/ouroboros",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_005_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "Ouroboros"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-star-of-azkaranth",
-    "url_name": "the-star-of-azkaranth",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-star-of-azkaranth",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_006_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "The Star of Azkaranth"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/xephirian-amulet",
-    "url_name": "xephirian-amulet",
-    "api_url": "https://us.battle.net/api/d3/data/item/xephirian-amulet",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_004_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "Xephirian Amulet"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/blackthornes-duncraig-cross",
-    "url_name": "blackthornes-duncraig-cross",
-    "api_url": "https://us.battle.net/api/d3/data/item/blackthornes-duncraig-cross",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_016_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "set",
-    "name": "Blackthorne's Duncraig Cross"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/tal-rashas-allegiance",
-    "url_name": "tal-rashas-allegiance",
-    "api_url": "https://us.battle.net/api/d3/data/item/tal-rashas-allegiance",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_007_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "set",
-    "name": "Tal Rasha's Allegiance"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-travelers-pledge",
-    "url_name": "the-travelers-pledge",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-travelers-pledge",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_008_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "set",
-    "name": "The Traveler's Pledge"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/halcyons-ascent",
-    "url_name": "halcyons-ascent",
-    "api_url": "https://us.battle.net/api/d3/data/item/halcyons-ascent",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_109_x1_210_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "legendary",
-    "name": "Halcyon's Ascent"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/sunwukos-shines",
-    "url_name": "sunwukos-shines",
-    "api_url": "https://us.battle.net/api/d3/data/item/sunwukos-shines",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_set_11_x1_demonhunter_male.png",
-    "type": "amulet",
-    "quality": "set",
-    "name": "Sunwuko's Shines"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/jeweler/recipe/hellfire-ring-of-strength",
-    "url_name": "hellfire-ring-of-strength",
-    "api_url": "https://us.battle.net/api/d3/data/item/hellfire-ring-of-strength",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_024_104_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Hellfire Ring"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/jeweler/recipe/hellfire-ring-of-intelligence",
-    "url_name": "hellfire-ring-of-intelligence",
-    "api_url": "https://us.battle.net/api/d3/data/item/hellfire-ring-of-intelligence",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_024_104_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Hellfire Ring"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/jeweler/recipe/hellfire-ring-of-vitality",
-    "url_name": "hellfire-ring-of-vitality",
-    "api_url": "https://us.battle.net/api/d3/data/item/hellfire-ring-of-vitality",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_024_104_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Hellfire Ring"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/jeweler/recipe/hellfire-ring-of-dexterity",
-    "url_name": "hellfire-ring-of-dexterity",
-    "api_url": "https://us.battle.net/api/d3/data/item/hellfire-ring-of-dexterity",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_024_104_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Hellfire Ring"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/jeweler/recipe/hellfire-ring",
-    "url_name": "hellfire-ring",
-    "api_url": "https://us.battle.net/api/d3/data/item/hellfire-ring",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_024_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Hellfire Ring"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/band-of-might",
-    "url_name": "band-of-might",
-    "api_url": "https://us.battle.net/api/d3/data/item/band-of-might",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_ring_05_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Band of Might"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/manald-heal",
-    "url_name": "manald-heal",
-    "api_url": "https://us.battle.net/api/d3/data/item/manald-heal",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_021_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Manald Heal"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/avarice-band",
-    "url_name": "avarice-band",
-    "api_url": "https://us.battle.net/api/d3/data/item/avarice-band",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_108_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Avarice Band"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/leorics-signet",
-    "url_name": "leorics-signet",
-    "api_url": "https://us.battle.net/api/d3/data/item/leorics-signet",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_002_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Leoric's Signet"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/pandemonium-loop",
-    "url_name": "pandemonium-loop",
-    "api_url": "https://us.battle.net/api/d3/data/item/pandemonium-loop",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_109_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Pandemonium Loop"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/ring-of-royal-grandeur",
-    "url_name": "ring-of-royal-grandeur",
-    "api_url": "https://us.battle.net/api/d3/data/item/ring-of-royal-grandeur",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_107_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Ring of Royal Grandeur"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/broken-promises",
-    "url_name": "broken-promises",
-    "api_url": "https://us.battle.net/api/d3/data/item/broken-promises",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_006_p2_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Broken Promises"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/puzzle-ring",
-    "url_name": "puzzle-ring",
-    "api_url": "https://us.battle.net/api/d3/data/item/puzzle-ring",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_004_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Puzzle Ring"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/arcstone",
-    "url_name": "arcstone",
-    "api_url": "https://us.battle.net/api/d3/data/item/arcstone",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_ring_03_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Arcstone"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/band-of-the-rue-chambers",
-    "url_name": "band-of-the-rue-chambers",
-    "api_url": "https://us.battle.net/api/d3/data/item/band-of-the-rue-chambers",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_106_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Band of the Rue Chambers"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/rechels-ring-of-larceny",
-    "url_name": "rechels-ring-of-larceny",
-    "api_url": "https://us.battle.net/api/d3/data/item/rechels-ring-of-larceny",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_104_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Rechel's Ring of Larceny"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/rogars-huge-stone",
-    "url_name": "rogars-huge-stone",
-    "api_url": "https://us.battle.net/api/d3/data/item/rogars-huge-stone",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_103_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Rogar's Huge Stone"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-short-mans-finger",
-    "url_name": "the-short-mans-finger",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-short-mans-finger",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_ring_02_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "The Short Man's Finger"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-tall-mans-finger",
-    "url_name": "the-tall-mans-finger",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-tall-mans-finger",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_101_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "The Tall Man's Finger"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/wyrdward",
-    "url_name": "wyrdward",
-    "api_url": "https://us.battle.net/api/d3/data/item/wyrdward",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_102_p2_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Wyrdward"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/nagelring",
-    "url_name": "nagelring",
-    "api_url": "https://us.battle.net/api/d3/data/item/nagelring",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_018_p2_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Nagelring"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/bulkathoss-wedding-band",
-    "url_name": "bulkathoss-wedding-band",
-    "api_url": "https://us.battle.net/api/d3/data/item/bulkathoss-wedding-band",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_020_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Bul-Kathos's Wedding Band"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/eternal-union",
-    "url_name": "eternal-union",
-    "api_url": "https://us.battle.net/api/d3/data/item/eternal-union",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_007_p1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Eternal Union"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/justice-lantern",
-    "url_name": "justice-lantern",
-    "api_url": "https://us.battle.net/api/d3/data/item/justice-lantern",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_ring_03_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Justice Lantern"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/obsidian-ring-of-the-zodiac",
-    "url_name": "obsidian-ring-of-the-zodiac",
-    "api_url": "https://us.battle.net/api/d3/data/item/obsidian-ring-of-the-zodiac",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_023_p2_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Obsidian Ring of the Zodiac"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/convention-of-elements",
-    "url_name": "convention-of-elements",
-    "api_url": "https://us.battle.net/api/d3/data/item/convention-of-elements",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_ring_04_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Convention of Elements"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/elusive-ring",
-    "url_name": "elusive-ring",
-    "api_url": "https://us.battle.net/api/d3/data/item/elusive-ring",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_ring_02_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Elusive Ring"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/halo-of-arlyse",
-    "url_name": "halo-of-arlyse",
-    "api_url": "https://us.battle.net/api/d3/data/item/halo-of-arlyse",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_ring_wizard_001_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Halo of Arlyse"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/ring-of-emptiness",
-    "url_name": "ring-of-emptiness",
-    "api_url": "https://us.battle.net/api/d3/data/item/ring-of-emptiness",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_ring_01_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Ring of Emptiness "
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/band-of-hollow-whispers",
-    "url_name": "band-of-hollow-whispers",
-    "api_url": "https://us.battle.net/api/d3/data/item/band-of-hollow-whispers",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_001_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Band of Hollow Whispers"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/kredes-flame",
-    "url_name": "kredes-flame",
-    "api_url": "https://us.battle.net/api/d3/data/item/kredes-flame",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_003_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Krede's Flame"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/oculus-ring",
-    "url_name": "oculus-ring",
-    "api_url": "https://us.battle.net/api/d3/data/item/oculus-ring",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_017_p4_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Oculus Ring"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/skull-grasp",
-    "url_name": "skull-grasp",
-    "api_url": "https://us.battle.net/api/d3/data/item/skull-grasp",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_ring_01_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Skull Grasp"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/stone-of-jordan",
-    "url_name": "stone-of-jordan",
-    "api_url": "https://us.battle.net/api/d3/data/item/stone-of-jordan",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_019_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Stone of Jordan"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/unity",
-    "url_name": "unity",
-    "api_url": "https://us.battle.net/api/d3/data/item/unity",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_010_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "legendary",
-    "name": "Unity"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/litany-of-the-undaunted",
-    "url_name": "litany-of-the-undaunted",
-    "api_url": "https://us.battle.net/api/d3/data/item/litany-of-the-undaunted",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_015_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "set",
-    "name": "Litany of the Undaunted"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/natalyas-reflection",
-    "url_name": "natalyas-reflection",
-    "api_url": "https://us.battle.net/api/d3/data/item/natalyas-reflection",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_011_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "set",
-    "name": "Natalya's Reflection"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-compass-rose",
-    "url_name": "the-compass-rose",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-compass-rose",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_013_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "set",
-    "name": "The Compass Rose"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-wailing-host",
-    "url_name": "the-wailing-host",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-wailing-host",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_014_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "set",
-    "name": "The Wailing Host"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/zunimassas-pox",
-    "url_name": "zunimassas-pox",
-    "api_url": "https://us.battle.net/api/d3/data/item/zunimassas-pox",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_012_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "set",
-    "name": "Zunimassa's Pox"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/focus",
-    "url_name": "focus",
-    "api_url": "https://us.battle.net/api/d3/data/item/focus",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_set_001_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "set",
-    "name": "Focus"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/restraint",
-    "url_name": "restraint",
-    "api_url": "https://us.battle.net/api/d3/data/item/restraint",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_set_002_x1_demonhunter_male.png",
-    "type": "ring",
-    "quality": "set",
-    "name": "Restraint"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/covens-criterion",
-    "url_name": "covens-criterion",
-    "api_url": "https://us.battle.net/api/d3/data/item/covens-criterion",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_107_x1_demonhunter_male.png",
-    "type": "shield",
-    "quality": "legendary",
-    "name": "Coven's Criterion"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/denial",
-    "url_name": "denial",
-    "api_url": "https://us.battle.net/api/d3/data/item/denial",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_shield_007_demonhunter_male.png",
-    "type": "shield",
-    "quality": "legendary",
-    "name": "Denial"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/wall-of-bone",
-    "url_name": "wall-of-bone",
-    "api_url": "https://us.battle.net/api/d3/data/item/wall-of-bone",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_011_1xx_demonhunter_male.png",
-    "type": "shield",
-    "quality": "legendary",
-    "name": "Wall of Bone"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/defender-of-westmarch",
-    "url_name": "defender-of-westmarch",
-    "api_url": "https://us.battle.net/api/d3/data/item/defender-of-westmarch",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_101_p2_demonhunter_male.png",
-    "type": "shield",
-    "quality": "legendary",
-    "name": "Defender of Westmarch"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/eberli-charo",
-    "url_name": "eberli-charo",
-    "api_url": "https://us.battle.net/api/d3/data/item/eberli-charo",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_102_x1_demonhunter_male.png",
-    "type": "shield",
-    "quality": "legendary",
-    "name": "Eberli Charo"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/freeze-of-deflection",
-    "url_name": "freeze-of-deflection",
-    "api_url": "https://us.battle.net/api/d3/data/item/freeze-of-deflection",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_004_x1_demonhunter_male.png",
-    "type": "shield",
-    "quality": "legendary",
-    "name": "Freeze of Deflection"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/votoyias-spiker",
-    "url_name": "votoyias-spiker",
-    "api_url": "https://us.battle.net/api/d3/data/item/votoyias-spiker",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_104_x1_demonhunter_male.png",
-    "type": "shield",
-    "quality": "legendary",
-    "name": "Vo'Toyias Spiker"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/lidless-wall",
-    "url_name": "lidless-wall",
-    "api_url": "https://us.battle.net/api/d3/data/item/lidless-wall",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_008_x1_demonhunter_male.png",
-    "type": "shield",
-    "quality": "legendary",
-    "name": "Lidless Wall"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/ivory-tower",
-    "url_name": "ivory-tower",
-    "api_url": "https://us.battle.net/api/d3/data/item/ivory-tower",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_shield_002_demonhunter_male.png",
-    "type": "shield",
-    "quality": "legendary",
-    "name": "Ivory Tower"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/stormshield",
-    "url_name": "stormshield",
-    "api_url": "https://us.battle.net/api/d3/data/item/stormshield",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_009_x1_demonhunter_male.png",
-    "type": "shield",
-    "quality": "legendary",
-    "name": "Stormshield"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-barrier",
-    "url_name": "hallowed-barrier",
-    "api_url": "https://us.battle.net/api/d3/data/item/hallowed-barrier",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_012_1xx_demonhunter_male.png",
-    "type": "shield",
-    "quality": "set",
-    "name": "Hallowed Defender"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/wall-of-man",
-    "url_name": "wall-of-man",
-    "api_url": "https://us.battle.net/api/d3/data/item/wall-of-man",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_011_x1_demonhunter_male.png",
-    "type": "shield",
-    "quality": "legendary",
-    "name": "Wall of Man"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-barricade",
-    "url_name": "hallowed-barricade",
-    "api_url": "https://us.battle.net/api/d3/data/item/hallowed-barricade",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_012_x1_demonhunter_male.png",
-    "type": "shield",
-    "quality": "set",
-    "name": "Hallowed Barricade"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/guard-of-johanna",
-    "url_name": "guard-of-johanna",
-    "api_url": "https://us.battle.net/api/d3/data/item/guard-of-johanna",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_103_x1_demonhunter_male.png",
-    "type": "crusader-shield",
-    "quality": "legendary",
-    "name": "Guard of Johanna"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/salvation",
-    "url_name": "salvation",
-    "api_url": "https://us.battle.net/api/d3/data/item/salvation",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_crushield_108_x1_demonhunter_male.png",
-    "type": "crusader-shield",
-    "quality": "legendary",
-    "name": "Salvation"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/shield-of-fury",
-    "url_name": "shield-of-fury",
-    "api_url": "https://us.battle.net/api/d3/data/item/shield-of-fury",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_106_x1_demonhunter_male.png",
-    "type": "crusader-shield",
-    "quality": "legendary",
-    "name": "Shield of Fury"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/akarats-awakening",
-    "url_name": "akarats-awakening",
-    "api_url": "https://us.battle.net/api/d3/data/item/akarats-awakening",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_crushield_104_x1_demonhunter_male.png",
-    "type": "crusader-shield",
-    "quality": "legendary",
-    "name": "Akarat's Awakening"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/hallowed-bulwark",
-    "url_name": "hallowed-bulwark",
-    "api_url": "https://us.battle.net/api/d3/data/item/hallowed-bulwark",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_crushield_103_x1_demonhunter_male.png",
-    "type": "crusader-shield",
-    "quality": "legendary",
-    "name": "Hallowed Bulwark"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/hellskull",
-    "url_name": "hellskull",
-    "api_url": "https://us.battle.net/api/d3/data/item/hellskull",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_crushield_105_x1_demonhunter_male.png",
-    "type": "crusader-shield",
-    "quality": "legendary",
-    "name": "Hellskull"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/jekangbord",
-    "url_name": "jekangbord",
-    "api_url": "https://us.battle.net/api/d3/data/item/jekangbord",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_crushield_102_x1_demonhunter_male.png",
-    "type": "crusader-shield",
-    "quality": "legendary",
-    "name": "Jekangbord"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/sublime-conviction",
-    "url_name": "sublime-conviction",
-    "api_url": "https://us.battle.net/api/d3/data/item/sublime-conviction",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_crushield_106_x1_demonhunter_male.png",
-    "type": "crusader-shield",
-    "quality": "legendary",
-    "name": "Sublime Conviction"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-final-witness",
-    "url_name": "the-final-witness",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-final-witness",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_crushield_107_x1_demonhunter_male.png",
-    "type": "crusader-shield",
-    "quality": "legendary",
-    "name": "The Final Witness"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/frydehrs-wrath",
-    "url_name": "frydehrs-wrath",
-    "api_url": "https://us.battle.net/api/d3/data/item/frydehrs-wrath",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p1_crushield_norm_unique_01_demonhunter_male.png",
-    "type": "crusader-shield",
-    "quality": "legendary",
-    "name": "Frydehr's Wrath"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/piro-marella",
-    "url_name": "piro-marella",
-    "api_url": "https://us.battle.net/api/d3/data/item/piro-marella",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_crushield_101_x1_demonhunter_male.png",
-    "type": "crusader-shield",
-    "quality": "legendary",
-    "name": "Piro Marella"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/unrelenting-phalanx",
-    "url_name": "unrelenting-phalanx",
-    "api_url": "https://us.battle.net/api/d3/data/item/unrelenting-phalanx",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p1_crushield_norm_unique_02_demonhunter_male.png",
-    "type": "crusader-shield",
-    "quality": "legendary",
-    "name": "Unrelenting Phalanx"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/shield-of-the-steed",
-    "url_name": "shield-of-the-steed",
-    "api_url": "https://us.battle.net/api/d3/data/item/shield-of-the-steed",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_shield_set_01_x1_demonhunter_male.png",
-    "type": "crusader-shield",
-    "quality": "set",
-    "name": "Shield of the Steed"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/gazing-demise",
-    "url_name": "gazing-demise",
-    "api_url": "https://us.battle.net/api/d3/data/item/gazing-demise",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mojo_003_x1_demonhunter_male.png",
-    "type": "mojo",
-    "quality": "legendary",
-    "name": "Gazing Demise"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/homunculus",
-    "url_name": "homunculus",
-    "api_url": "https://us.battle.net/api/d3/data/item/homunculus",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mojo_004_p2_demonhunter_male.png",
-    "type": "mojo",
-    "quality": "legendary",
-    "name": "Homunculus"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/bitterness",
-    "url_name": "bitterness",
-    "api_url": "https://us.battle.net/api/d3/data/item/bitterness",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mojo_002_1xx_demonhunter_male.png",
-    "type": "mojo",
-    "quality": "legendary",
-    "name": "Bitterness"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/shukranis-triumph",
-    "url_name": "shukranis-triumph",
-    "api_url": "https://us.battle.net/api/d3/data/item/shukranis-triumph",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mojo_102_x1_demonhunter_male.png",
-    "type": "mojo",
-    "quality": "legendary",
-    "name": "Shukrani's Triumph"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/thing-of-the-deep",
-    "url_name": "thing-of-the-deep",
-    "api_url": "https://us.battle.net/api/d3/data/item/thing-of-the-deep",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_mojo_002_demonhunter_male.png",
-    "type": "mojo",
-    "quality": "legendary",
-    "name": "Thing of the Deep"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/uhkapian-serpent",
-    "url_name": "uhkapian-serpent",
-    "api_url": "https://us.battle.net/api/d3/data/item/uhkapian-serpent",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mojo_008_x1_demonhunter_male.png",
-    "type": "mojo",
-    "quality": "legendary",
-    "name": "Uhkapian Serpent"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/manajumas-gory-fetch",
-    "url_name": "manajumas-gory-fetch",
-    "api_url": "https://us.battle.net/api/d3/data/item/manajumas-gory-fetch",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mojo_010_x1_demonhunter_male.png",
-    "type": "mojo",
-    "quality": "set",
-    "name": "Manajuma's Gory Fetch"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/zunimassas-string-of-skulls",
-    "url_name": "zunimassas-string-of-skulls",
-    "api_url": "https://us.battle.net/api/d3/data/item/zunimassas-string-of-skulls",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mojo_011_x1_demonhunter_male.png",
-    "type": "mojo",
-    "quality": "set",
-    "name": "Zunimassa's String of Skulls"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/henris-perquisition",
-    "url_name": "henris-perquisition",
-    "api_url": "https://us.battle.net/api/d3/data/item/henris-perquisition",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_mojo_norm_unique_02_demonhunter_male.png",
-    "type": "mojo",
-    "quality": "legendary",
-    "name": "Henri’s Perquisition"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/spite",
-    "url_name": "spite",
-    "api_url": "https://us.battle.net/api/d3/data/item/spite",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mojo_002_x1_demonhunter_male.png",
-    "type": "mojo",
-    "quality": "legendary",
-    "name": "Spite"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/vile-hive",
-    "url_name": "vile-hive",
-    "api_url": "https://us.battle.net/api/d3/data/item/vile-hive",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_mojo_001_demonhunter_male.png",
-    "type": "mojo",
-    "quality": "legendary",
-    "name": "Vile Hive"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/wilkens-reach",
-    "url_name": "wilkens-reach",
-    "api_url": "https://us.battle.net/api/d3/data/item/wilkens-reach",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_mojo_003_demonhunter_male.png",
-    "type": "mojo",
-    "quality": "legendary",
-    "name": "Wilken's Reach"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/winter-flurry",
-    "url_name": "winter-flurry",
-    "api_url": "https://us.battle.net/api/d3/data/item/winter-flurry",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_orb_005_x1_demonhunter_male.png",
-    "type": "orb",
-    "quality": "legendary",
-    "name": "Winter Flurry"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/etched-sigil",
-    "url_name": "etched-sigil",
-    "api_url": "https://us.battle.net/api/d3/data/item/etched-sigil",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_orb_002_demonhunter_male.png",
-    "type": "orb",
-    "quality": "legendary",
-    "name": "Etched Sigil"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/light-of-grace",
-    "url_name": "light-of-grace",
-    "api_url": "https://us.battle.net/api/d3/data/item/light-of-grace",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_orb_103_x1_demonhunter_male.png",
-    "type": "orb",
-    "quality": "legendary",
-    "name": "Light of Grace"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/mirrorball",
-    "url_name": "mirrorball",
-    "api_url": "https://us.battle.net/api/d3/data/item/mirrorball",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_orb_101_x1_demonhunter_male.png",
-    "type": "orb",
-    "quality": "legendary",
-    "name": "Mirrorball"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/mykens-ball-of-hate",
-    "url_name": "mykens-ball-of-hate",
-    "api_url": "https://us.battle.net/api/d3/data/item/mykens-ball-of-hate",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_orb_102_x1_demonhunter_male.png",
-    "type": "orb",
-    "quality": "legendary",
-    "name": "Myken's Ball of Hate"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/singularity",
-    "url_name": "singularity",
-    "api_url": "https://us.battle.net/api/d3/data/item/singularity",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_orb_004_1xx_demonhunter_male.png",
-    "type": "orb",
-    "quality": "legendary",
-    "name": "Singularity"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-oculus",
-    "url_name": "the-oculus",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-oculus",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_orb_001_x1_demonhunter_male.png",
-    "type": "orb",
-    "quality": "legendary",
-    "name": "The Oculus"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/triumvirate",
-    "url_name": "triumvirate",
-    "api_url": "https://us.battle.net/api/d3/data/item/triumvirate",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_orb_003_demonhunter_male.png",
-    "type": "orb",
-    "quality": "legendary",
-    "name": "Triumvirate"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/chantodos-force",
-    "url_name": "chantodos-force",
-    "api_url": "https://us.battle.net/api/d3/data/item/chantodos-force",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_orb_011_x1_demonhunter_male.png",
-    "type": "orb",
-    "quality": "set",
-    "name": "Chantodo's Force"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/tal-rashas-unwavering-glare",
-    "url_name": "tal-rashas-unwavering-glare",
-    "api_url": "https://us.battle.net/api/d3/data/item/tal-rashas-unwavering-glare",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_orb_012_x1_demonhunter_male.png",
-    "type": "orb",
-    "quality": "set",
-    "name": "Tal Rasha's Unwavering Glare"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/primordial-soul",
-    "url_name": "primordial-soul",
-    "api_url": "https://us.battle.net/api/d3/data/item/primordial-soul",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_orb_001_demonhunter_male.png",
-    "type": "orb",
-    "quality": "legendary",
-    "name": "Primordial Soul"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/cosmic-strand",
-    "url_name": "cosmic-strand",
-    "api_url": "https://us.battle.net/api/d3/data/item/cosmic-strand",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_orb_004_x1_demonhunter_male.png",
-    "type": "orb",
-    "quality": "legendary",
-    "name": "Cosmic Strand"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/orb-of-infinite-depth",
-    "url_name": "orb-of-infinite-depth",
-    "api_url": "https://us.battle.net/api/d3/data/item/orb-of-infinite-depth",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_orb_004_demonhunter_male.png",
-    "type": "orb",
-    "quality": "legendary",
-    "name": "Orb of Infinite Depth"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/firebirds-eye",
-    "url_name": "firebirds-eye",
-    "api_url": "https://us.battle.net/api/d3/data/item/firebirds-eye",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_orb_set_06_x1_demonhunter_male.png",
-    "type": "orb",
-    "quality": "set",
-    "name": "Firebird's Eye"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/fletchers-pride",
-    "url_name": "fletchers-pride",
-    "api_url": "https://us.battle.net/api/d3/data/item/fletchers-pride",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_quiver_006_x1_demonhunter_male.png",
-    "type": "quiver",
-    "quality": "legendary",
-    "name": "Fletcher's Pride"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/sin-seekers",
-    "url_name": "sin-seekers",
-    "api_url": "https://us.battle.net/api/d3/data/item/sin-seekers",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_quiver_001_demonhunter_male.png",
-    "type": "quiver",
-    "quality": "legendary",
-    "name": "Sin Seekers"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/holy-point-shot",
-    "url_name": "holy-point-shot",
-    "api_url": "https://us.battle.net/api/d3/data/item/holy-point-shot",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_quiver_004_x1_demonhunter_male.png",
-    "type": "quiver",
-    "quality": "legendary",
-    "name": "Holy Point Shot"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/spines-of-seething-hatred",
-    "url_name": "spines-of-seething-hatred",
-    "api_url": "https://us.battle.net/api/d3/data/item/spines-of-seething-hatred",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_quiver_005_p1_demonhunter_male.png",
-    "type": "quiver",
-    "quality": "legendary",
-    "name": "Spines of Seething Hatred"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/bombardiers-rucksack",
-    "url_name": "bombardiers-rucksack",
-    "api_url": "https://us.battle.net/api/d3/data/item/bombardiers-rucksack",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_quiver_102_x1_demonhunter_male.png",
-    "type": "quiver",
-    "quality": "legendary",
-    "name": "Bombardier's Rucksack"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/emimeis-duffel",
-    "url_name": "emimeis-duffel",
-    "api_url": "https://us.battle.net/api/d3/data/item/emimeis-duffel",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_quiver_103_x1_demonhunter_male.png",
-    "type": "quiver",
-    "quality": "legendary",
-    "name": "Emimei's Duffel"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-ninth-cirri-satchel",
-    "url_name": "the-ninth-cirri-satchel",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-ninth-cirri-satchel",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_quiver_101_x1_demonhunter_male.png",
-    "type": "quiver",
-    "quality": "legendary",
-    "name": "The Ninth Cirri Satchel"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/meticulous-bolts",
-    "url_name": "meticulous-bolts",
-    "api_url": "https://us.battle.net/api/d3/data/item/meticulous-bolts",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_quiver_001_p1_demonhunter_male.png",
-    "type": "quiver",
-    "quality": "legendary",
-    "name": "Meticulous Bolts"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/dead-mans-legacy",
-    "url_name": "dead-mans-legacy",
-    "api_url": "https://us.battle.net/api/d3/data/item/dead-mans-legacy",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_quiver_007_demonhunter_male.png",
-    "type": "quiver",
-    "quality": "legendary",
-    "name": "Dead Man's Legacy"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/black-bone-arrows",
-    "url_name": "black-bone-arrows",
-    "api_url": "https://us.battle.net/api/d3/data/item/black-bone-arrows",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_quiver_003_1xx_demonhunter_male.png",
-    "type": "quiver",
-    "quality": "legendary",
-    "name": "Black Bone Arrows"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/archfiend-arrows",
-    "url_name": "archfiend-arrows",
-    "api_url": "https://us.battle.net/api/d3/data/item/archfiend-arrows",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_quiver_003_x1_demonhunter_male.png",
-    "type": "quiver",
-    "quality": "legendary",
-    "name": "Archfiend Arrows"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/hand-of-the-prophet",
-    "url_name": "hand-of-the-prophet",
-    "api_url": "https://us.battle.net/api/d3/data/item/hand-of-the-prophet",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/x1_followeritem_enchantress_legendary_02_demonhunter_male.png",
-    "type": "enchantress-focus",
-    "quality": "legendary",
-    "name": "Hand of the Prophet"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/smoking-thurible",
-    "url_name": "smoking-thurible",
-    "api_url": "https://us.battle.net/api/d3/data/item/smoking-thurible",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/x1_followeritem_enchantress_legendary_01_demonhunter_male.png",
-    "type": "enchantress-focus",
-    "quality": "legendary",
-    "name": "Smoking Thurible"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/vadims-surge",
-    "url_name": "vadims-surge",
-    "api_url": "https://us.battle.net/api/d3/data/item/vadims-surge",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/x1_followeritem_enchantress_legendary_03_demonhunter_male.png",
-    "type": "enchantress-focus",
-    "quality": "legendary",
-    "name": "Vadim's Surge"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/ribald-etchings",
-    "url_name": "ribald-etchings",
-    "api_url": "https://us.battle.net/api/d3/data/item/ribald-etchings",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/x1_followeritem_scoundrel_legendary_02_demonhunter_male.png",
-    "type": "scoundrel-token",
-    "quality": "legendary",
-    "name": "Ribald Etchings"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/skeleton-key",
-    "url_name": "skeleton-key",
-    "api_url": "https://us.battle.net/api/d3/data/item/skeleton-key",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/x1_followeritem_scoundrel_legendary_01_demonhunter_male.png",
-    "type": "scoundrel-token",
-    "quality": "legendary",
-    "name": "Skeleton Key"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/slipkas-letter-opener",
-    "url_name": "slipkas-letter-opener",
-    "api_url": "https://us.battle.net/api/d3/data/item/slipkas-letter-opener",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/x1_followeritem_scoundrel_legendary_03_demonhunter_male.png",
-    "type": "scoundrel-token",
-    "quality": "legendary",
-    "name": "Slipka's Letter Opener"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/enchanting-favor",
-    "url_name": "enchanting-favor",
-    "api_url": "https://us.battle.net/api/d3/data/item/enchanting-favor",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/x1_followeritem_templar_legendary_01_demonhunter_male.png",
-    "type": "templar-relic",
-    "quality": "legendary",
-    "name": "Enchanting Favor"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/hillenbrands-training-sword",
-    "url_name": "hillenbrands-training-sword",
-    "api_url": "https://us.battle.net/api/d3/data/item/hillenbrands-training-sword",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/x1_followeritem_templar_legendary_03_demonhunter_male.png",
-    "type": "templar-relic",
-    "quality": "legendary",
-    "name": "Hillenbrand's Training Sword"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/relic-of-akarat",
-    "url_name": "relic-of-akarat",
-    "api_url": "https://us.battle.net/api/d3/data/item/relic-of-akarat",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/x1_followeritem_templar_legendary_02_demonhunter_male.png",
-    "type": "templar-relic",
-    "quality": "legendary",
-    "name": "Relic of Akarat"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/genzaniku",
-    "url_name": "genzaniku",
-    "api_url": "https://us.battle.net/api/d3/data/item/genzaniku",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_1h_003_x1_demonhunter_male.png",
-    "type": "axe-1h",
-    "quality": "legendary",
-    "name": "Genzaniku"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/flesh-tearer",
-    "url_name": "flesh-tearer",
-    "api_url": "https://us.battle.net/api/d3/data/item/flesh-tearer",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_1h_001_x1_demonhunter_male.png",
-    "type": "axe-1h",
-    "quality": "legendary",
-    "name": "Flesh Tearer"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/hack",
-    "url_name": "hack",
-    "api_url": "https://us.battle.net/api/d3/data/item/hack",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_1h_103_x1_demonhunter_male.png",
-    "type": "axe-1h",
-    "quality": "legendary",
-    "name": "Hack"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/the-wedge",
-    "url_name": "the-wedge",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-wedge",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_1h_004_1xx_demonhunter_male.png",
-    "type": "axe-1h",
-    "quality": "legendary",
-    "name": "The Wedge"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-butchers-sickle",
-    "url_name": "the-butchers-sickle",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-butchers-sickle",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_1h_006_x1_demonhunter_male.png",
-    "type": "axe-1h",
-    "quality": "legendary",
-    "name": "The Butcher's Sickle"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/sky-splitter",
-    "url_name": "sky-splitter",
-    "api_url": "https://us.battle.net/api/d3/data/item/sky-splitter",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_1h_005_p2_demonhunter_male.png",
-    "type": "axe-1h",
-    "quality": "legendary",
-    "name": "Sky Splitter"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-burning-axe-of-sankis",
-    "url_name": "the-burning-axe-of-sankis",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-burning-axe-of-sankis",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_1h_007_x1_demonhunter_male.png",
-    "type": "axe-1h",
-    "quality": "legendary",
-    "name": "The Burning Axe of Sankis"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-divide",
-    "url_name": "hallowed-divide",
-    "api_url": "https://us.battle.net/api/d3/data/item/hallowed-divide",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_1h_013_1xx_demonhunter_male.png",
-    "type": "axe-1h",
-    "quality": "set",
-    "name": "Hallowed Storm"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/mordullus-promise",
-    "url_name": "mordullus-promise",
-    "api_url": "https://us.battle.net/api/d3/data/item/mordullus-promise",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_axe_1h_102_demonhunter_male.png",
-    "type": "axe-1h",
-    "quality": "legendary",
-    "name": "Mordullu's Promise"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/utars-roar",
-    "url_name": "utars-roar",
-    "api_url": "https://us.battle.net/api/d3/data/item/utars-roar",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_1h_004_x1_demonhunter_male.png",
-    "type": "axe-1h",
-    "quality": "legendary",
-    "name": "Utar's Roar"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-breach",
-    "url_name": "hallowed-breach",
-    "api_url": "https://us.battle.net/api/d3/data/item/hallowed-breach",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_1h_013_x1_demonhunter_male.png",
-    "type": "axe-1h",
-    "quality": "set",
-    "name": "Hallowed Breach"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-barber",
-    "url_name": "the-barber",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-barber",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_dagger_003_x1_demonhunter_male.png",
-    "type": "dagger",
-    "quality": "legendary",
-    "name": "The Barber"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/envious-blade",
-    "url_name": "envious-blade",
-    "api_url": "https://us.battle.net/api/d3/data/item/envious-blade",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_dagger_103_x1_demonhunter_male.png",
-    "type": "dagger",
-    "quality": "legendary",
-    "name": "Envious Blade"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/pig-sticker",
-    "url_name": "pig-sticker",
-    "api_url": "https://us.battle.net/api/d3/data/item/pig-sticker",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_dagger_007_x1_demonhunter_male.png",
-    "type": "dagger",
-    "quality": "legendary",
-    "name": "Pig Sticker"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/wizardspike",
-    "url_name": "wizardspike",
-    "api_url": "https://us.battle.net/api/d3/data/item/wizardspike",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_dagger_010_x1_210_demonhunter_male.png",
-    "type": "dagger",
-    "quality": "legendary",
-    "name": "Wizardspike"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/bloodmagic-blade",
-    "url_name": "bloodmagic-blade",
-    "api_url": "https://us.battle.net/api/d3/data/item/bloodmagic-blade",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_dagger_006_1xx_demonhunter_male.png",
-    "type": "dagger",
-    "quality": "legendary",
-    "name": "Blood-Magic Blade"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/bloodmagic-edge",
-    "url_name": "bloodmagic-edge",
-    "api_url": "https://us.battle.net/api/d3/data/item/bloodmagic-edge",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_dagger_006_x1_demonhunter_male.png",
-    "type": "dagger",
-    "quality": "legendary",
-    "name": "Blood-Magic Edge"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/eunjangdo",
-    "url_name": "eunjangdo",
-    "api_url": "https://us.battle.net/api/d3/data/item/eunjangdo",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_dagger_104_x1_demonhunter_male.png",
-    "type": "dagger",
-    "quality": "legendary",
-    "name": "Eun-jang-do"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/karleis-point",
-    "url_name": "karleis-point",
-    "api_url": "https://us.battle.net/api/d3/data/item/karleis-point",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_dagger_101_x1_demonhunter_male.png",
-    "type": "dagger",
-    "quality": "legendary",
-    "name": "Karlei's Point"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/lord-greenstones-fan",
-    "url_name": "lord-greenstones-fan",
-    "api_url": "https://us.battle.net/api/d3/data/item/lord-greenstones-fan",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_dagger_102_x1_demonhunter_male.png",
-    "type": "dagger",
-    "quality": "legendary",
-    "name": "Lord Greenstone's Fan"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/odyn-son",
-    "url_name": "odyn-son",
-    "api_url": "https://us.battle.net/api/d3/data/item/odyn-son",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_002_x1_demonhunter_male.png",
-    "type": "mace-1h",
-    "quality": "legendary",
-    "name": "Odyn Son"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/mad-monarchs-scepter",
-    "url_name": "mad-monarchs-scepter",
-    "api_url": "https://us.battle.net/api/d3/data/item/mad-monarchs-scepter",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_101_x1_demonhunter_male.png",
-    "type": "mace-1h",
-    "quality": "legendary",
-    "name": "Mad Monarch's Scepter"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/nutcracker",
-    "url_name": "nutcracker",
-    "api_url": "https://us.battle.net/api/d3/data/item/nutcracker",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_005_x1_demonhunter_male.png",
-    "type": "mace-1h",
-    "quality": "legendary",
-    "name": "Nutcracker"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/telrandens-hand",
-    "url_name": "telrandens-hand",
-    "api_url": "https://us.battle.net/api/d3/data/item/telrandens-hand",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_007_x1_demonhunter_male.png",
-    "type": "mace-1h",
-    "quality": "legendary",
-    "name": "Telranden's Hand"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/jaces-hammer-of-vigilance",
-    "url_name": "jaces-hammer-of-vigilance",
-    "api_url": "https://us.battle.net/api/d3/data/item/jaces-hammer-of-vigilance",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_103_x1_demonhunter_male.png",
-    "type": "mace-1h",
-    "quality": "legendary",
-    "name": "Jace's Hammer of Vigilance"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/solanium",
-    "url_name": "solanium",
-    "api_url": "https://us.battle.net/api/d3/data/item/solanium",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_102_x1_demonhunter_male.png",
-    "type": "mace-1h",
-    "quality": "legendary",
-    "name": "Solanium"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/nailbiter",
-    "url_name": "nailbiter",
-    "api_url": "https://us.battle.net/api/d3/data/item/nailbiter",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_008_x1_demonhunter_male.png",
-    "type": "mace-1h",
-    "quality": "legendary",
-    "name": "Nailbiter"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/neanderthal",
-    "url_name": "neanderthal",
-    "api_url": "https://us.battle.net/api/d3/data/item/neanderthal",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_003_x1_demonhunter_male.png",
-    "type": "mace-1h",
-    "quality": "legendary",
-    "name": "Neanderthal"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/echoing-fury",
-    "url_name": "echoing-fury",
-    "api_url": "https://us.battle.net/api/d3/data/item/echoing-fury",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_001_x1_demonhunter_male.png",
-    "type": "mace-1h",
-    "quality": "legendary",
-    "name": "Echoing Fury"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/sun-keeper",
-    "url_name": "sun-keeper",
-    "api_url": "https://us.battle.net/api/d3/data/item/sun-keeper",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_011_x1_demonhunter_male.png",
-    "type": "mace-1h",
-    "quality": "legendary",
-    "name": "Sun Keeper"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/earthshatter",
-    "url_name": "earthshatter",
-    "api_url": "https://us.battle.net/api/d3/data/item/earthshatter",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_009_1xx_demonhunter_male.png",
-    "type": "mace-1h",
-    "quality": "legendary",
-    "name": "Earthshatter"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/devastator",
-    "url_name": "devastator",
-    "api_url": "https://us.battle.net/api/d3/data/item/devastator",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_009_x1_demonhunter_male.png",
-    "type": "mace-1h",
-    "quality": "legendary",
-    "name": "Devastator"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/arreats-law",
-    "url_name": "arreats-law",
-    "api_url": "https://us.battle.net/api/d3/data/item/arreats-law",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_spear_001_demonhunter_male.png",
-    "type": "spear",
-    "quality": "legendary",
-    "name": "Arreat's Law"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/scrimshaw",
-    "url_name": "scrimshaw",
-    "api_url": "https://us.battle.net/api/d3/data/item/scrimshaw",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spear_004_p3_demonhunter_male.png",
-    "type": "spear",
-    "quality": "legendary",
-    "name": "Scrimshaw"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-three-hundredth-spear",
-    "url_name": "the-three-hundredth-spear",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-three-hundredth-spear",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_spear_002_demonhunter_male.png",
-    "type": "spear",
-    "quality": "legendary",
-    "name": "The Three Hundredth Spear"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/empyrean-messenger",
-    "url_name": "empyrean-messenger",
-    "api_url": "https://us.battle.net/api/d3/data/item/empyrean-messenger",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spear_003_x1_demonhunter_male.png",
-    "type": "spear",
-    "quality": "legendary",
-    "name": "Empyrean Messenger"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/akanesh-the-herald-of-righteousness",
-    "url_name": "akanesh-the-herald-of-righteousness",
-    "api_url": "https://us.battle.net/api/d3/data/item/akanesh-the-herald-of-righteousness",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spear_101_x1_demonhunter_male.png",
-    "type": "spear",
-    "quality": "legendary",
-    "name": "Akanesh, the Herald of Righteousness"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/monster-hunter",
-    "url_name": "monster-hunter",
-    "api_url": "https://us.battle.net/api/d3/data/item/monster-hunter",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_017_x1_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "legendary",
-    "name": "Monster Hunter"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/wildwood",
-    "url_name": "wildwood",
-    "api_url": "https://us.battle.net/api/d3/data/item/wildwood",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_002_x1_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "legendary",
-    "name": "Wildwood"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/borns-seething-rage",
-    "url_name": "borns-seething-rage",
-    "api_url": "https://us.battle.net/api/d3/data/item/borns-seething-rage",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_018_1xx_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "set",
-    "name": "Born's Searing Spite"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/doombringer",
-    "url_name": "doombringer",
-    "api_url": "https://us.battle.net/api/d3/data/item/doombringer",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_014_x1_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "legendary",
-    "name": "Doombringer"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-ancient-bonesaber-of-zumakalis",
-    "url_name": "the-ancient-bonesaber-of-zumakalis",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-ancient-bonesaber-of-zumakalis",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_003_x1_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "legendary",
-    "name": "The Ancient Bonesaber of Zumakalis"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/exarian",
-    "url_name": "exarian",
-    "api_url": "https://us.battle.net/api/d3/data/item/exarian",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_102_x1_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "legendary",
-    "name": "Exarian"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/fulminator",
-    "url_name": "fulminator",
-    "api_url": "https://us.battle.net/api/d3/data/item/fulminator",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_sword_1h_104_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "legendary",
-    "name": "Fulminator"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/gift-of-silaria",
-    "url_name": "gift-of-silaria",
-    "api_url": "https://us.battle.net/api/d3/data/item/gift-of-silaria",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_103_x1_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "legendary",
-    "name": "Gift of Silaria"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/rimeheart",
-    "url_name": "rimeheart",
-    "api_url": "https://us.battle.net/api/d3/data/item/rimeheart",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_109_x1_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "legendary",
-    "name": "Rimeheart"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/thunderfury-blessed-blade-of-the-windseeker",
-    "url_name": "thunderfury-blessed-blade-of-the-windseeker",
-    "api_url": "https://us.battle.net/api/d3/data/item/thunderfury-blessed-blade-of-the-windseeker",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_101_x1_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "legendary",
-    "name": "Thunderfury, Blessed Blade of the Windseeker"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/sever",
-    "url_name": "sever",
-    "api_url": "https://us.battle.net/api/d3/data/item/sever",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_007_x1_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "legendary",
-    "name": "Sever"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/skycutter",
-    "url_name": "skycutter",
-    "api_url": "https://us.battle.net/api/d3/data/item/skycutter",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_004_x1_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "legendary",
-    "name": "Skycutter"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/azurewrath",
-    "url_name": "azurewrath",
-    "api_url": "https://us.battle.net/api/d3/data/item/azurewrath",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_sword_1h_012_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "legendary",
-    "name": "Azurewrath"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/devil-tongue",
-    "url_name": "devil-tongue",
-    "api_url": "https://us.battle.net/api/d3/data/item/devil-tongue",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_011_x1_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "legendary",
-    "name": "Devil Tongue"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/griswolds-masterpiece",
-    "url_name": "griswolds-masterpiece",
-    "api_url": "https://us.battle.net/api/d3/data/item/griswolds-masterpiece",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_019_1xx_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "legendary",
-    "name": "Griswold's Masterpiece"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/deathwish",
-    "url_name": "deathwish",
-    "api_url": "https://us.battle.net/api/d3/data/item/deathwish",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_112_x1_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "legendary",
-    "name": "Deathwish"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/griswolds-perfection",
-    "url_name": "griswolds-perfection",
-    "api_url": "https://us.battle.net/api/d3/data/item/griswolds-perfection",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_019_x1_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "legendary",
-    "name": "Griswold's Perfection"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/ingeom",
-    "url_name": "ingeom",
-    "api_url": "https://us.battle.net/api/d3/data/item/ingeom",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_113_x1_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "legendary",
-    "name": "In-geom"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/shard-of-hate",
-    "url_name": "shard-of-hate",
-    "api_url": "https://us.battle.net/api/d3/data/item/shard-of-hate",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_promo_02_x1_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "legendary",
-    "name": "Shard of Hate"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/sword-of-ill-will",
-    "url_name": "sword-of-ill-will",
-    "api_url": "https://us.battle.net/api/d3/data/item/sword-of-ill-will",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_sword_1h_01_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "legendary",
-    "name": "Sword of Ill Will"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-twisted-sword",
-    "url_name": "the-twisted-sword",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-twisted-sword",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_107_x1_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "legendary",
-    "name": "The Twisted Sword"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/borns-furious-wrath",
-    "url_name": "borns-furious-wrath",
-    "api_url": "https://us.battle.net/api/d3/data/item/borns-furious-wrath",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_018_x1_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "set",
-    "name": "Born's Furious Wrath"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/little-rogue",
-    "url_name": "little-rogue",
-    "api_url": "https://us.battle.net/api/d3/data/item/little-rogue",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_set_03_x1_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "set",
-    "name": "Little Rogue"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-slanderer",
-    "url_name": "the-slanderer",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-slanderer",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_set_02_x1_demonhunter_male.png",
-    "type": "sword-1h",
-    "quality": "set",
-    "name": "The Slanderer"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/deadly-rebirth",
-    "url_name": "deadly-rebirth",
-    "api_url": "https://us.battle.net/api/d3/data/item/deadly-rebirth",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ceremonialdagger_003_x1_demonhunter_male.png",
-    "type": "ceremonial-knife",
-    "quality": "legendary",
-    "name": "Deadly Rebirth"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/umbral-oath",
-    "url_name": "umbral-oath",
-    "api_url": "https://us.battle.net/api/d3/data/item/umbral-oath",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ceremonialdagger_006_1xx_demonhunter_male.png",
-    "type": "ceremonial-knife",
-    "quality": "legendary",
-    "name": "Umbral Oath"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/rhenho-flayer",
-    "url_name": "rhenho-flayer",
-    "api_url": "https://us.battle.net/api/d3/data/item/rhenho-flayer",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ceremonialdagger_102_x1_demonhunter_male.png",
-    "type": "ceremonial-knife",
-    "quality": "legendary",
-    "name": "Rhen'ho Flayer"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/sacred-harvester",
-    "url_name": "sacred-harvester",
-    "api_url": "https://us.battle.net/api/d3/data/item/sacred-harvester",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p1_ceremonialdagger_norm_unique_01_demonhunter_male.png",
-    "type": "ceremonial-knife",
-    "quality": "legendary",
-    "name": "Sacred Harvester"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-dagger-of-darts",
-    "url_name": "the-dagger-of-darts",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-dagger-of-darts",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p1_ceremonialdagger_norm_unique_02_demonhunter_male.png",
-    "type": "ceremonial-knife",
-    "quality": "legendary",
-    "name": "The Dagger of Darts"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/last-breath",
-    "url_name": "last-breath",
-    "api_url": "https://us.battle.net/api/d3/data/item/last-breath",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_ceremonialdagger_008_demonhunter_male.png",
-    "type": "ceremonial-knife",
-    "quality": "legendary",
-    "name": "Last Breath"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-spider-queens-grasp",
-    "url_name": "the-spider-queens-grasp",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-spider-queens-grasp",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ceremonialdagger_004_x1_demonhunter_male.png",
-    "type": "ceremonial-knife",
-    "quality": "legendary",
-    "name": "The Spider Queen's Grasp"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/starmetal-kukri",
-    "url_name": "starmetal-kukri",
-    "api_url": "https://us.battle.net/api/d3/data/item/starmetal-kukri",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ceremonialdagger_101_x1_demonhunter_male.png",
-    "type": "ceremonial-knife",
-    "quality": "legendary",
-    "name": "Starmetal Kukri"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/anessazi-edge",
-    "url_name": "anessazi-edge",
-    "api_url": "https://us.battle.net/api/d3/data/item/anessazi-edge",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ceremonialdagger_001_x1_demonhunter_male.png",
-    "type": "ceremonial-knife",
-    "quality": "legendary",
-    "name": "Anessazi Edge"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/voos-juicer",
-    "url_name": "voos-juicer",
-    "api_url": "https://us.battle.net/api/d3/data/item/voos-juicer",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_dagger_002_demonhunter_male.png",
-    "type": "ceremonial-knife",
-    "quality": "legendary",
-    "name": "Voo's Juicer"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-gidbinn",
-    "url_name": "the-gidbinn",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-gidbinn",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ceremonialdagger_002_x1_demonhunter_male.png",
-    "type": "ceremonial-knife",
-    "quality": "legendary",
-    "name": "The Gidbinn"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/manajumas-carving-knife",
-    "url_name": "manajumas-carving-knife",
-    "api_url": "https://us.battle.net/api/d3/data/item/manajumas-carving-knife",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ceremonialdagger_009_x1_demonhunter_male.png",
-    "type": "ceremonial-knife",
-    "quality": "set",
-    "name": "Manajuma's Carving Knife"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-sacrifice",
-    "url_name": "hallowed-sacrifice",
-    "api_url": "https://us.battle.net/api/d3/data/item/hallowed-sacrifice",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ceremonialdagger_011_1xx_demonhunter_male.png",
-    "type": "ceremonial-knife",
-    "quality": "set",
-    "name": "Hallowed Salvation"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/living-umbral-oath",
-    "url_name": "living-umbral-oath",
-    "api_url": "https://us.battle.net/api/d3/data/item/living-umbral-oath",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ceremonialdagger_006_x1_demonhunter_male.png",
-    "type": "ceremonial-knife",
-    "quality": "legendary",
-    "name": "Living Umbral Oath"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-sufferance",
-    "url_name": "hallowed-sufferance",
-    "api_url": "https://us.battle.net/api/d3/data/item/hallowed-sufferance",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ceremonialdagger_011_x1_demonhunter_male.png",
-    "type": "ceremonial-knife",
-    "quality": "set",
-    "name": "Hallowed Sufferance"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/fleshrake",
-    "url_name": "fleshrake",
-    "api_url": "https://us.battle.net/api/d3/data/item/fleshrake",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_007_x1_demonhunter_male.png",
-    "type": "fist-weapon",
-    "quality": "legendary",
-    "name": "Fleshrake"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/rabid-strike",
-    "url_name": "rabid-strike",
-    "api_url": "https://us.battle.net/api/d3/data/item/rabid-strike",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_003_x1_demonhunter_male.png",
-    "type": "fist-weapon",
-    "quality": "legendary",
-    "name": "Rabid Strike"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/scarbringer",
-    "url_name": "scarbringer",
-    "api_url": "https://us.battle.net/api/d3/data/item/scarbringer",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_013_x1_demonhunter_male.png",
-    "type": "fist-weapon",
-    "quality": "legendary",
-    "name": "Scarbringer"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/sledge-fist",
-    "url_name": "sledge-fist",
-    "api_url": "https://us.battle.net/api/d3/data/item/sledge-fist",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_012_x1_demonhunter_male.png",
-    "type": "fist-weapon",
-    "quality": "legendary",
-    "name": "Sledge Fist"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/jawbreaker",
-    "url_name": "jawbreaker",
-    "api_url": "https://us.battle.net/api/d3/data/item/jawbreaker",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_101_x1_demonhunter_male.png",
-    "type": "fist-weapon",
-    "quality": "legendary",
-    "name": "Jawbreaker"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/logans-claw",
-    "url_name": "logans-claw",
-    "api_url": "https://us.battle.net/api/d3/data/item/logans-claw",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_005_x1_demonhunter_male.png",
-    "type": "fist-weapon",
-    "quality": "legendary",
-    "name": "Logan's Claw"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demon-hand",
-    "url_name": "demon-hand",
-    "api_url": "https://us.battle.net/api/d3/data/item/demon-hand",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_004_1xx_demonhunter_male.png",
-    "type": "fist-weapon",
-    "quality": "legendary",
-    "name": "Demon Hand"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/crystal-fist",
-    "url_name": "crystal-fist",
-    "api_url": "https://us.battle.net/api/d3/data/item/crystal-fist",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_008_x1_demonhunter_male.png",
-    "type": "fist-weapon",
-    "quality": "legendary",
-    "name": "Crystal Fist"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-fist-of-azturrasq",
-    "url_name": "the-fist-of-azturrasq",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-fist-of-azturrasq",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_fist_009_x1_demonhunter_male.png",
-    "type": "fist-weapon",
-    "quality": "legendary",
-    "name": "The Fist of Az'Turrasq"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/won-khim-lau",
-    "url_name": "won-khim-lau",
-    "api_url": "https://us.battle.net/api/d3/data/item/won-khim-lau",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_006_x1_demonhunter_male.png",
-    "type": "fist-weapon",
-    "quality": "legendary",
-    "name": "Won Khim Lau"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/shenlongs-fist-of-legend",
-    "url_name": "shenlongs-fist-of-legend",
-    "api_url": "https://us.battle.net/api/d3/data/item/shenlongs-fist-of-legend",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_011_x1_demonhunter_male.png",
-    "type": "fist-weapon",
-    "quality": "set",
-    "name": "Shenlong's Fist of Legend"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/shenlongs-relentless-assault",
-    "url_name": "shenlongs-relentless-assault",
-    "api_url": "https://us.battle.net/api/d3/data/item/shenlongs-relentless-assault",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_010_x1_demonhunter_male.png",
-    "type": "fist-weapon",
-    "quality": "set",
-    "name": "Shenlong's Relentless Assault"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-touch",
-    "url_name": "hallowed-touch",
-    "api_url": "https://us.battle.net/api/d3/data/item/hallowed-touch",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_015_1xx_demonhunter_male.png",
-    "type": "fist-weapon",
-    "quality": "set",
-    "name": "Hallowed Hand"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demon-claw",
-    "url_name": "demon-claw",
-    "api_url": "https://us.battle.net/api/d3/data/item/demon-claw",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_004_x1_demonhunter_male.png",
-    "type": "fist-weapon",
-    "quality": "legendary",
-    "name": "Demon Claw"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/kyoshiros-blade",
-    "url_name": "kyoshiros-blade",
-    "api_url": "https://us.battle.net/api/d3/data/item/kyoshiros-blade",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_fist_102_demonhunter_male.png",
-    "type": "fist-weapon",
-    "quality": "legendary",
-    "name": "Kyoshiro's Blade"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/lions-claw",
-    "url_name": "lions-claw",
-    "api_url": "https://us.battle.net/api/d3/data/item/lions-claw",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p1_fistweapon_norm_unique_01_demonhunter_male.png",
-    "type": "fist-weapon",
-    "quality": "legendary",
-    "name": "Lion’s Claw"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/vengeful-wind",
-    "url_name": "vengeful-wind",
-    "api_url": "https://us.battle.net/api/d3/data/item/vengeful-wind",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_fistweapon_norm_unique_02_demonhunter_male.png",
-    "type": "fist-weapon",
-    "quality": "legendary",
-    "name": "Vengeful Wind"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-hold",
-    "url_name": "hallowed-hold",
-    "api_url": "https://us.battle.net/api/d3/data/item/hallowed-hold",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_015_x1_demonhunter_male.png",
-    "type": "fist-weapon",
-    "quality": "set",
-    "name": "Hallowed Hold"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/johannas-argument",
-    "url_name": "johannas-argument",
-    "api_url": "https://us.battle.net/api/d3/data/item/johannas-argument",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p1_flail1h_norm_unique_01_demonhunter_male.png",
-    "type": "flail-1h",
-    "quality": "legendary",
-    "name": "Johanna's Argument"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/darklight",
-    "url_name": "darklight",
-    "api_url": "https://us.battle.net/api/d3/data/item/darklight",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_flail_1h_106_x1_demonhunter_male.png",
-    "type": "flail-1h",
-    "quality": "legendary",
-    "name": "Darklight"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/gyrfalcons-foote",
-    "url_name": "gyrfalcons-foote",
-    "api_url": "https://us.battle.net/api/d3/data/item/gyrfalcons-foote",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_flail_1h_105_x1_demonhunter_male.png",
-    "type": "flail-1h",
-    "quality": "legendary",
-    "name": "Gyrfalcon's Foote"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/inviolable-faith",
-    "url_name": "inviolable-faith",
-    "api_url": "https://us.battle.net/api/d3/data/item/inviolable-faith",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_flail_1h_107_x1_demonhunter_male.png",
-    "type": "flail-1h",
-    "quality": "legendary",
-    "name": "Inviolable Faith"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/justinians-mercy",
-    "url_name": "justinians-mercy",
-    "api_url": "https://us.battle.net/api/d3/data/item/justinians-mercy",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_flail_1h_102_x1_demonhunter_male.png",
-    "type": "flail-1h",
-    "quality": "legendary",
-    "name": "Justinian's Mercy"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/kassars-retribution",
-    "url_name": "kassars-retribution",
-    "api_url": "https://us.battle.net/api/d3/data/item/kassars-retribution",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_flail_1h_104_x1_demonhunter_male.png",
-    "type": "flail-1h",
-    "quality": "legendary",
-    "name": "Kassar's Retribution"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/swiftmount",
-    "url_name": "swiftmount",
-    "api_url": "https://us.battle.net/api/d3/data/item/swiftmount",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_flail_1h_103_x1_demonhunter_male.png",
-    "type": "flail-1h",
-    "quality": "legendary",
-    "name": "Swiftmount"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/golden-scourge",
-    "url_name": "golden-scourge",
-    "api_url": "https://us.battle.net/api/d3/data/item/golden-scourge",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_flail_1h_101_x1_demonhunter_male.png",
-    "type": "flail-1h",
-    "quality": "legendary",
-    "name": "Golden Scourge"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/fjord-cutter",
-    "url_name": "fjord-cutter",
-    "api_url": "https://us.battle.net/api/d3/data/item/fjord-cutter",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_mighty_1h_006_demonhunter_male.png",
-    "type": "mighty-weapon-1h",
-    "quality": "legendary",
-    "name": "Fjord Cutter"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/ambos-pride",
-    "url_name": "ambos-pride",
-    "api_url": "https://us.battle.net/api/d3/data/item/ambos-pride",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_1h_012_x1_demonhunter_male.png",
-    "type": "mighty-weapon-1h",
-    "quality": "legendary",
-    "name": "Ambo's Pride"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/harvest-moon",
-    "url_name": "harvest-moon",
-    "api_url": "https://us.battle.net/api/d3/data/item/harvest-moon",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_1h_001_1xx_demonhunter_male.png",
-    "type": "mighty-weapon-1h",
-    "quality": "legendary",
-    "name": "Harvest Moon"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/blade-of-the-warlord",
-    "url_name": "blade-of-the-warlord",
-    "api_url": "https://us.battle.net/api/d3/data/item/blade-of-the-warlord",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_mighty_1h_005_demonhunter_male.png",
-    "type": "mighty-weapon-1h",
-    "quality": "legendary",
-    "name": "Blade of the Warlord"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/bulkathoss-solemn-vow",
-    "url_name": "bulkathoss-solemn-vow",
-    "api_url": "https://us.battle.net/api/d3/data/item/bulkathoss-solemn-vow",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_1h_010_x1_demonhunter_male.png",
-    "type": "mighty-weapon-1h",
-    "quality": "set",
-    "name": "Bul-Kathos's Solemn Vow"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/bulkathoss-warrior-blood",
-    "url_name": "bulkathoss-warrior-blood",
-    "api_url": "https://us.battle.net/api/d3/data/item/bulkathoss-warrior-blood",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_1h_011_x1_demonhunter_male.png",
-    "type": "mighty-weapon-1h",
-    "quality": "set",
-    "name": "Bul-Kathos's Warrior Blood"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-destroyer",
-    "url_name": "hallowed-destroyer",
-    "api_url": "https://us.battle.net/api/d3/data/item/hallowed-destroyer",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_1h_015_1xx_demonhunter_male.png",
-    "type": "mighty-weapon-1h",
-    "quality": "set",
-    "name": "Hallowed Reckoning"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/dishonored-legacy",
-    "url_name": "dishonored-legacy",
-    "api_url": "https://us.battle.net/api/d3/data/item/dishonored-legacy",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_1h_103_x1_demonhunter_male.png",
-    "type": "mighty-weapon-1h",
-    "quality": "legendary",
-    "name": "Dishonored Legacy"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/nights-reaping",
-    "url_name": "nights-reaping",
-    "api_url": "https://us.battle.net/api/d3/data/item/nights-reaping",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_1h_001_x1_demonhunter_male.png",
-    "type": "mighty-weapon-1h",
-    "quality": "legendary",
-    "name": "Night's Reaping"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/oathkeeper",
-    "url_name": "oathkeeper",
-    "api_url": "https://us.battle.net/api/d3/data/item/oathkeeper",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_mighty_1h_104_demonhunter_male.png",
-    "type": "mighty-weapon-1h",
-    "quality": "legendary",
-    "name": "Oathkeeper"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/remorseless",
-    "url_name": "remorseless",
-    "api_url": "https://us.battle.net/api/d3/data/item/remorseless",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_1h_102_x1_demonhunter_male.png",
-    "type": "mighty-weapon-1h",
-    "quality": "legendary",
-    "name": "Remorseless"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-nemesis",
-    "url_name": "hallowed-nemesis",
-    "api_url": "https://us.battle.net/api/d3/data/item/hallowed-nemesis",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_1h_015_x1_demonhunter_male.png",
-    "type": "mighty-weapon-1h",
-    "quality": "set",
-    "name": "Hallowed Nemesis"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-executioner",
-    "url_name": "the-executioner",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-executioner",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_2h_003_x1_demonhunter_male.png",
-    "type": "axe-2h",
-    "quality": "legendary",
-    "name": "The Executioner"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/burst-of-wrath",
-    "url_name": "burst-of-wrath",
-    "api_url": "https://us.battle.net/api/d3/data/item/burst-of-wrath",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_2h_103_x1_demonhunter_male.png",
-    "type": "axe-2h",
-    "quality": "legendary",
-    "name": "Burst of Wrath"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/butchers-carver",
-    "url_name": "butchers-carver",
-    "api_url": "https://us.battle.net/api/d3/data/item/butchers-carver",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_2h_001_x1_demonhunter_male.png",
-    "type": "axe-2h",
-    "quality": "legendary",
-    "name": "Butcher's Carver"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/messerschmidts-reaver",
-    "url_name": "messerschmidts-reaver",
-    "api_url": "https://us.battle.net/api/d3/data/item/messerschmidts-reaver",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_2h_011_x1_demonhunter_male.png",
-    "type": "axe-2h",
-    "quality": "legendary",
-    "name": "Messerschmidt's Reaver"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/skorn",
-    "url_name": "skorn",
-    "api_url": "https://us.battle.net/api/d3/data/item/skorn",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_2h_009_x1_demonhunter_male.png",
-    "type": "axe-2h",
-    "quality": "legendary",
-    "name": "Skorn"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/fire-brand",
-    "url_name": "fire-brand",
-    "api_url": "https://us.battle.net/api/d3/data/item/fire-brand",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_2h_010_1xx_demonhunter_male.png",
-    "type": "axe-2h",
-    "quality": "legendary",
-    "name": "Fire Brand"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/cinder-switch",
-    "url_name": "cinder-switch",
-    "api_url": "https://us.battle.net/api/d3/data/item/cinder-switch",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_2h_010_x1_demonhunter_male.png",
-    "type": "axe-2h",
-    "quality": "legendary",
-    "name": "Cinder Switch"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/arthefs-spark-of-life",
-    "url_name": "arthefs-spark-of-life",
-    "api_url": "https://us.battle.net/api/d3/data/item/arthefs-spark-of-life",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_2h_003_x1_demonhunter_male.png",
-    "type": "mace-2h",
-    "quality": "legendary",
-    "name": "Arthef's Spark of Life"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/crushbane",
-    "url_name": "crushbane",
-    "api_url": "https://us.battle.net/api/d3/data/item/crushbane",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_2h_001_x1_demonhunter_male.png",
-    "type": "mace-2h",
-    "quality": "legendary",
-    "name": "Crushbane"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/soulsmasher",
-    "url_name": "soulsmasher",
-    "api_url": "https://us.battle.net/api/d3/data/item/soulsmasher",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_2h_104_x1_demonhunter_male.png",
-    "type": "mace-2h",
-    "quality": "legendary",
-    "name": "Soulsmasher"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/skywarden",
-    "url_name": "skywarden",
-    "api_url": "https://us.battle.net/api/d3/data/item/skywarden",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_2h_010_x1_demonhunter_male.png",
-    "type": "mace-2h",
-    "quality": "legendary",
-    "name": "Skywarden"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/wrath-of-the-bone-king",
-    "url_name": "wrath-of-the-bone-king",
-    "api_url": "https://us.battle.net/api/d3/data/item/wrath-of-the-bone-king",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_2h_012_p1_demonhunter_male.png",
-    "type": "mace-2h",
-    "quality": "legendary",
-    "name": "Wrath of the Bone King"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-furnace",
-    "url_name": "the-furnace",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-furnace",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_2h_103_x1_demonhunter_male.png",
-    "type": "mace-2h",
-    "quality": "legendary",
-    "name": "The Furnace"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/cataclysm",
-    "url_name": "cataclysm",
-    "api_url": "https://us.battle.net/api/d3/data/item/cataclysm",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_2h_006_1xx_demonhunter_male.png",
-    "type": "mace-2h",
-    "quality": "legendary",
-    "name": "Cataclysm"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/schaefers-hammer",
-    "url_name": "schaefers-hammer",
-    "api_url": "https://us.battle.net/api/d3/data/item/schaefers-hammer",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_2h_009_p2_demonhunter_male.png",
-    "type": "mace-2h",
-    "quality": "legendary",
-    "name": "Schaefer's Hammer"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/sledge-of-athskeleng",
-    "url_name": "sledge-of-athskeleng",
-    "api_url": "https://us.battle.net/api/d3/data/item/sledge-of-athskeleng",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_2h_002_x1_demonhunter_male.png",
-    "type": "mace-2h",
-    "quality": "legendary",
-    "name": "Sledge of Athskeleng"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/sunder",
-    "url_name": "sunder",
-    "api_url": "https://us.battle.net/api/d3/data/item/sunder",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_2h_006_x1_demonhunter_male.png",
-    "type": "mace-2h",
-    "quality": "legendary",
-    "name": "Sunder"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/pledge-of-caldeum",
-    "url_name": "pledge-of-caldeum",
-    "api_url": "https://us.battle.net/api/d3/data/item/pledge-of-caldeum",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_polearm_002_x1_demonhunter_male.png",
-    "type": "polearm",
-    "quality": "legendary",
-    "name": "Pledge of Caldeum"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/standoff",
-    "url_name": "standoff",
-    "api_url": "https://us.battle.net/api/d3/data/item/standoff",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_polearm_01_demonhunter_male.png",
-    "type": "polearm",
-    "quality": "legendary",
-    "name": "Standoff"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/bovine-bardiche",
-    "url_name": "bovine-bardiche",
-    "api_url": "https://us.battle.net/api/d3/data/item/bovine-bardiche",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_polearm_101_x1_demonhunter_male.png",
-    "type": "polearm",
-    "quality": "legendary",
-    "name": "Bovine Bardiche"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/heart-slaughter",
-    "url_name": "heart-slaughter",
-    "api_url": "https://us.battle.net/api/d3/data/item/heart-slaughter",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_polearm_003_p1_demonhunter_male.png",
-    "type": "polearm",
-    "quality": "legendary",
-    "name": "Heart Slaughter"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/vigilance",
-    "url_name": "vigilance",
-    "api_url": "https://us.battle.net/api/d3/data/item/vigilance",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_polearm_001_x1_demonhunter_male.png",
-    "type": "polearm",
-    "quality": "legendary",
-    "name": "Vigilance"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/staff-of-chiroptera",
-    "url_name": "staff-of-chiroptera",
-    "api_url": "https://us.battle.net/api/d3/data/item/staff-of-chiroptera",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_staff_001_demonhunter_male.png",
-    "type": "staff",
-    "quality": "legendary",
-    "name": "Staff of Chiroptera"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-broken-staff",
-    "url_name": "the-broken-staff",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-broken-staff",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_staff_001_x1_demonhunter_male.png",
-    "type": "staff",
-    "quality": "legendary",
-    "name": "The Broken Staff"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/ahavarion-spear-of-lycander",
-    "url_name": "ahavarion-spear-of-lycander",
-    "api_url": "https://us.battle.net/api/d3/data/item/ahavarion-spear-of-lycander",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_staff_101_x1_demonhunter_male.png",
-    "type": "staff",
-    "quality": "legendary",
-    "name": "Ahavarion, Spear of Lycander"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/suwong-diviner",
-    "url_name": "suwong-diviner",
-    "api_url": "https://us.battle.net/api/d3/data/item/suwong-diviner",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_staff_104_x1_demonhunter_male.png",
-    "type": "staff",
-    "quality": "legendary",
-    "name": "SuWong Diviner"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-smoldering-core",
-    "url_name": "the-smoldering-core",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-smoldering-core",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_staff_103_x1_demonhunter_male.png",
-    "type": "staff",
-    "quality": "legendary",
-    "name": "The Smoldering Core"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/valtheks-rebuke",
-    "url_name": "valtheks-rebuke",
-    "api_url": "https://us.battle.net/api/d3/data/item/valtheks-rebuke",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_staff_102_x1_demonhunter_male.png",
-    "type": "staff",
-    "quality": "legendary",
-    "name": "Valthek's Rebuke"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/the-magi",
-    "url_name": "the-magi",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-magi",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_staff_002_1xx_demonhunter_male.png",
-    "type": "staff",
-    "quality": "legendary",
-    "name": "The Magi"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/maloths-focus",
-    "url_name": "maloths-focus",
-    "api_url": "https://us.battle.net/api/d3/data/item/maloths-focus",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_staff_006_x1_demonhunter_male.png",
-    "type": "staff",
-    "quality": "legendary",
-    "name": "Maloth's Focus"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/wormwood",
-    "url_name": "wormwood",
-    "api_url": "https://us.battle.net/api/d3/data/item/wormwood",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_staff_003_demonhunter_male.png",
-    "type": "staff",
-    "quality": "legendary",
-    "name": "Wormwood"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-grand-vizier",
-    "url_name": "the-grand-vizier",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-grand-vizier",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_staff_009_p1_demonhunter_male.png",
-    "type": "staff",
-    "quality": "legendary",
-    "name": "The Grand Vizier"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-tormentor",
-    "url_name": "the-tormentor",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-tormentor",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_staff_007_x1_demonhunter_male.png",
-    "type": "staff",
-    "quality": "legendary",
-    "name": "The Tormentor"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/mark-of-the-magi",
-    "url_name": "mark-of-the-magi",
-    "api_url": "https://us.battle.net/api/d3/data/item/mark-of-the-magi",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_staff_002_x1_demonhunter_male.png",
-    "type": "staff",
-    "quality": "legendary",
-    "name": "Mark of The Magi"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/faithful-memory",
-    "url_name": "faithful-memory",
-    "api_url": "https://us.battle.net/api/d3/data/item/faithful-memory",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_012_x1_demonhunter_male.png",
-    "type": "sword-2h",
-    "quality": "legendary",
-    "name": "Faithful Memory"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-zweihander",
-    "url_name": "the-zweihander",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-zweihander",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_002_x1_demonhunter_male.png",
-    "type": "sword-2h",
-    "quality": "legendary",
-    "name": "The Zweihander"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/blackguard",
-    "url_name": "blackguard",
-    "api_url": "https://us.battle.net/api/d3/data/item/blackguard",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_011_x1_demonhunter_male.png",
-    "type": "sword-2h",
-    "quality": "legendary",
-    "name": "Blackguard"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/scourge",
-    "url_name": "scourge",
-    "api_url": "https://us.battle.net/api/d3/data/item/scourge",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_004_x1_demonhunter_male.png",
-    "type": "sword-2h",
-    "quality": "legendary",
-    "name": "Scourge"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/stalgards-decimator",
-    "url_name": "stalgards-decimator",
-    "api_url": "https://us.battle.net/api/d3/data/item/stalgards-decimator",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_101_x1_demonhunter_male.png",
-    "type": "sword-2h",
-    "quality": "legendary",
-    "name": "Stalgard's Decimator"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/blade-of-prophecy",
-    "url_name": "blade-of-prophecy",
-    "api_url": "https://us.battle.net/api/d3/data/item/blade-of-prophecy",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_007_x1_demonhunter_male.png",
-    "type": "sword-2h",
-    "quality": "legendary",
-    "name": "Blade of Prophecy"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-sultan-of-blinding-sand",
-    "url_name": "the-sultan-of-blinding-sand",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-sultan-of-blinding-sand",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_008_x1_demonhunter_male.png",
-    "type": "sword-2h",
-    "quality": "legendary",
-    "name": "The Sultan of Blinding Sand"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/maximus",
-    "url_name": "maximus",
-    "api_url": "https://us.battle.net/api/d3/data/item/maximus",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_010_x1_demonhunter_male.png",
-    "type": "sword-2h",
-    "quality": "legendary",
-    "name": "Maximus"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-grandfather",
-    "url_name": "the-grandfather",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-grandfather",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_001_x1_demonhunter_male.png",
-    "type": "sword-2h",
-    "quality": "legendary",
-    "name": "The Grandfather"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/warmonger",
-    "url_name": "warmonger",
-    "api_url": "https://us.battle.net/api/d3/data/item/warmonger",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_003_x1_demonhunter_male.png",
-    "type": "sword-2h",
-    "quality": "legendary",
-    "name": "Warmonger"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/cams-rebuttal",
-    "url_name": "cams-rebuttal",
-    "api_url": "https://us.battle.net/api/d3/data/item/cams-rebuttal",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_102_x1_demonhunter_male.png",
-    "type": "sword-2h",
-    "quality": "legendary",
-    "name": "Cam's Rebuttal"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/blood-brother",
-    "url_name": "blood-brother",
-    "api_url": "https://us.battle.net/api/d3/data/item/blood-brother",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_103_x1_demonhunter_male.png",
-    "type": "sword-2h",
-    "quality": "legendary",
-    "name": "Blood Brother"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/corrupted-ashbringer",
-    "url_name": "corrupted-ashbringer",
-    "api_url": "https://us.battle.net/api/d3/data/item/corrupted-ashbringer",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_104_x1_demonhunter_male.png",
-    "type": "sword-2h",
-    "quality": "legendary",
-    "name": "Corrupted Ashbringer"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/balance",
-    "url_name": "balance",
-    "api_url": "https://us.battle.net/api/d3/data/item/balance",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_combatstaff_2h_001_demonhunter_male.png",
-    "type": "daibo",
-    "quality": "legendary",
-    "name": "Balance"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/lai-yuis-taiji",
-    "url_name": "lai-yuis-taiji",
-    "api_url": "https://us.battle.net/api/d3/data/item/lai-yuis-taiji",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_combatstaff_2h_008_1xx_demonhunter_male.png",
-    "type": "daibo",
-    "quality": "legendary",
-    "name": "Lai Yui's Taiji"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-flow-of-eternity",
-    "url_name": "the-flow-of-eternity",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-flow-of-eternity",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_combatstaff_2h_005_x1_demonhunter_male.png",
-    "type": "daibo",
-    "quality": "legendary",
-    "name": "The Flow of Eternity"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-paddle",
-    "url_name": "the-paddle",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-paddle",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_combatstaff_2h_007_x1_demonhunter_male.png",
-    "type": "daibo",
-    "quality": "legendary",
-    "name": "The Paddle"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/staff-of-kyro",
-    "url_name": "staff-of-kyro",
-    "api_url": "https://us.battle.net/api/d3/data/item/staff-of-kyro",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_combatstaff_2h_101_x1_demonhunter_male.png",
-    "type": "daibo",
-    "quality": "legendary",
-    "name": "Staff of Kyro"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/warstaff-of-general-quang",
-    "url_name": "warstaff-of-general-quang",
-    "api_url": "https://us.battle.net/api/d3/data/item/warstaff-of-general-quang",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_combatstaff_2h_102_x1_demonhunter_male.png",
-    "type": "daibo",
-    "quality": "legendary",
-    "name": "Warstaff of General Quang"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/incense-torch-of-the-grand-temple",
-    "url_name": "incense-torch-of-the-grand-temple",
-    "api_url": "https://us.battle.net/api/d3/data/item/incense-torch-of-the-grand-temple",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_combatstaff_2h_003_x1_demonhunter_male.png",
-    "type": "daibo",
-    "quality": "legendary",
-    "name": "Incense Torch of the Grand Temple"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/flying-dragon",
-    "url_name": "flying-dragon",
-    "api_url": "https://us.battle.net/api/d3/data/item/flying-dragon",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_combatstaff_2h_009_x1_demonhunter_male.png",
-    "type": "daibo",
-    "quality": "legendary",
-    "name": "Flying Dragon"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/innas-reach",
-    "url_name": "innas-reach",
-    "api_url": "https://us.battle.net/api/d3/data/item/innas-reach",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_combatstaff_2h_001_x1_demonhunter_male.png",
-    "type": "daibo",
-    "quality": "set",
-    "name": "Inna's Reach"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/rozpedins-staff",
-    "url_name": "rozpedins-staff",
-    "api_url": "https://us.battle.net/api/d3/data/item/rozpedins-staff",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_combatstaff_2h_004_1xx_demonhunter_male.png",
-    "type": "daibo",
-    "quality": "legendary",
-    "name": "Rozpedin's Staff"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/lai-yuis-persuader",
-    "url_name": "lai-yuis-persuader",
-    "api_url": "https://us.battle.net/api/d3/data/item/lai-yuis-persuader",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_combatstaff_2h_008_x1_demonhunter_male.png",
-    "type": "daibo",
-    "quality": "legendary",
-    "name": "Lai Yui's Persuader"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/rozpedins-force",
-    "url_name": "rozpedins-force",
-    "api_url": "https://us.battle.net/api/d3/data/item/rozpedins-force",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_combatstaff_2h_004_x1_demonhunter_male.png",
-    "type": "daibo",
-    "quality": "legendary",
-    "name": "Rozpedin's Force"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/akkhans-addendum",
-    "url_name": "akkhans-addendum",
-    "api_url": "https://us.battle.net/api/d3/data/item/akkhans-addendum",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_flail_2h_001_demonhunter_male.png",
-    "type": "flail-2h",
-    "quality": "legendary",
-    "name": "Akkhan's Addendum"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/baleful-remnant",
-    "url_name": "baleful-remnant",
-    "api_url": "https://us.battle.net/api/d3/data/item/baleful-remnant",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_flail_2h_102_x1_demonhunter_male.png",
-    "type": "flail-2h",
-    "quality": "legendary",
-    "name": "Baleful Remnant"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/fate-of-the-fell",
-    "url_name": "fate-of-the-fell",
-    "api_url": "https://us.battle.net/api/d3/data/item/fate-of-the-fell",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_flail_2h_103_x1_demonhunter_male.png",
-    "type": "flail-2h",
-    "quality": "legendary",
-    "name": "Fate of the Fell"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/golden-flense",
-    "url_name": "golden-flense",
-    "api_url": "https://us.battle.net/api/d3/data/item/golden-flense",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_flail_2h_104_demonhunter_male.png",
-    "type": "flail-2h",
-    "quality": "legendary",
-    "name": "Golden Flense"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-mortal-drama",
-    "url_name": "the-mortal-drama",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-mortal-drama",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_flail_2h_101_x1_demonhunter_male.png",
-    "type": "flail-2h",
-    "quality": "legendary",
-    "name": "The Mortal Drama"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/akkhans-leniency",
-    "url_name": "akkhans-leniency",
-    "api_url": "https://us.battle.net/api/d3/data/item/akkhans-leniency",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_flail2h_norm_unique_01_demonhunter_male.png",
-    "type": "flail-2h",
-    "quality": "legendary",
-    "name": "Akkhan’s Leniency"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/flail-of-the-charge",
-    "url_name": "flail-of-the-charge",
-    "api_url": "https://us.battle.net/api/d3/data/item/flail-of-the-charge",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_flail_2h_set_01_x1_demonhunter_male.png",
-    "type": "flail-2h",
-    "quality": "set",
-    "name": "Flail of the Charge"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/unending-war",
-    "url_name": "unending-war",
-    "api_url": "https://us.battle.net/api/d3/data/item/unending-war",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_2h_012_1xx_demonhunter_male.png",
-    "type": "mighty-weapon-2h",
-    "quality": "legendary",
-    "name": "Unending War"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/bastions-revered",
-    "url_name": "bastions-revered",
-    "api_url": "https://us.battle.net/api/d3/data/item/bastions-revered",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_2h_004_p1_demonhunter_male.png",
-    "type": "mighty-weapon-2h",
-    "quality": "legendary",
-    "name": "Bastion's Revered"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/fury-of-the-vanished-peak",
-    "url_name": "fury-of-the-vanished-peak",
-    "api_url": "https://us.battle.net/api/d3/data/item/fury-of-the-vanished-peak",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_mighty_2h_006_demonhunter_male.png",
-    "type": "mighty-weapon-2h",
-    "quality": "legendary",
-    "name": "Fury of the Vanished Peak"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/madawcs-sorrow",
-    "url_name": "madawcs-sorrow",
-    "api_url": "https://us.battle.net/api/d3/data/item/madawcs-sorrow",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_2h_101_x1_demonhunter_male.png",
-    "type": "mighty-weapon-2h",
-    "quality": "legendary",
-    "name": "Madawc's Sorrow"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-gavel-of-judgment",
-    "url_name": "the-gavel-of-judgment",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-gavel-of-judgment",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_mighty_2h_001_demonhunter_male.png",
-    "type": "mighty-weapon-2h",
-    "quality": "legendary",
-    "name": "The Gavel of Judgment"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/immortal-kings-boulder-breaker",
-    "url_name": "immortal-kings-boulder-breaker",
-    "api_url": "https://us.battle.net/api/d3/data/item/immortal-kings-boulder-breaker",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_2h_010_x1_demonhunter_male.png",
-    "type": "mighty-weapon-2h",
-    "quality": "set",
-    "name": "Immortal King's Boulder Breaker"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/blade-of-the-tribes",
-    "url_name": "blade-of-the-tribes",
-    "api_url": "https://us.battle.net/api/d3/data/item/blade-of-the-tribes",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_mighty_2h_101_demonhunter_male.png",
-    "type": "mighty-weapon-2h",
-    "quality": "legendary",
-    "name": "Blade of the Tribes"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/war-of-the-dead",
-    "url_name": "war-of-the-dead",
-    "api_url": "https://us.battle.net/api/d3/data/item/war-of-the-dead",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_2h_012_x1_demonhunter_male.png",
-    "type": "mighty-weapon-2h",
-    "quality": "legendary",
-    "name": "War of the Dead"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/uskang",
-    "url_name": "uskang",
-    "api_url": "https://us.battle.net/api/d3/data/item/uskang",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_005_p1_demonhunter_male.png",
-    "type": "bow",
-    "quality": "legendary",
-    "name": "Uskang"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/longshot",
-    "url_name": "longshot",
-    "api_url": "https://us.battle.net/api/d3/data/item/longshot",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_007_1xx_demonhunter_male.png",
-    "type": "bow",
-    "quality": "legendary",
-    "name": "Longshot"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/etrayu",
-    "url_name": "etrayu",
-    "api_url": "https://us.battle.net/api/d3/data/item/etrayu",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_001_p1_demonhunter_male.png",
-    "type": "bow",
-    "quality": "legendary",
-    "name": "Etrayu"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-ravens-wing",
-    "url_name": "the-ravens-wing",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-ravens-wing",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_008_x1_demonhunter_male.png",
-    "type": "bow",
-    "quality": "legendary",
-    "name": "The Raven's Wing"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/kridershot",
-    "url_name": "kridershot",
-    "api_url": "https://us.battle.net/api/d3/data/item/kridershot",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_101_x1_demonhunter_male.png",
-    "type": "bow",
-    "quality": "legendary",
-    "name": "Kridershot"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/cluckeye",
-    "url_name": "cluckeye",
-    "api_url": "https://us.battle.net/api/d3/data/item/cluckeye",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_015_x1_demonhunter_male.png",
-    "type": "bow",
-    "quality": "legendary",
-    "name": "Cluckeye"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/windforce",
-    "url_name": "windforce",
-    "api_url": "https://us.battle.net/api/d3/data/item/windforce",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_009_x1_demonhunter_male.png",
-    "type": "bow",
-    "quality": "legendary",
-    "name": "Windforce"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/venomhusk",
-    "url_name": "venomhusk",
-    "api_url": "https://us.battle.net/api/d3/data/item/venomhusk",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_010_1xx_demonhunter_male.png",
-    "type": "bow",
-    "quality": "legendary",
-    "name": "Venomhusk"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/leonine-bow-of-hashir",
-    "url_name": "leonine-bow-of-hashir",
-    "api_url": "https://us.battle.net/api/d3/data/item/leonine-bow-of-hashir",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_103_x1_demonhunter_male.png",
-    "type": "bow",
-    "quality": "legendary",
-    "name": "Leonine Bow of Hashir"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/odysseys-end",
-    "url_name": "odysseys-end",
-    "api_url": "https://us.battle.net/api/d3/data/item/odysseys-end",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_102_x1_demonhunter_male.png",
-    "type": "bow",
-    "quality": "legendary",
-    "name": "Odyssey's End"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/sydyru-crust",
-    "url_name": "sydyru-crust",
-    "api_url": "https://us.battle.net/api/d3/data/item/sydyru-crust",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_010_x1_demonhunter_male.png",
-    "type": "bow",
-    "quality": "legendary",
-    "name": "Sydyru Crust"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/unbound-bolt",
-    "url_name": "unbound-bolt",
-    "api_url": "https://us.battle.net/api/d3/data/item/unbound-bolt",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_007_x1_demonhunter_male.png",
-    "type": "bow",
-    "quality": "legendary",
-    "name": "Unbound Bolt"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/yangs-recurve",
-    "url_name": "yangs-recurve",
-    "api_url": "https://us.battle.net/api/d3/data/item/yangs-recurve",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_104_x1_demonhunter_male.png",
-    "type": "bow",
-    "quality": "legendary",
-    "name": "Yang's Recurve"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/demon-machine",
-    "url_name": "demon-machine",
-    "api_url": "https://us.battle.net/api/d3/data/item/demon-machine",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_xbow_001_x1_demonhunter_male.png",
-    "type": "crossbow",
-    "quality": "legendary",
-    "name": "Demon Machine"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/burizado-kyanon",
-    "url_name": "burizado-kyanon",
-    "api_url": "https://us.battle.net/api/d3/data/item/burizado-kyanon",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_xbow_011_x1_demonhunter_male.png",
-    "type": "crossbow",
-    "quality": "legendary",
-    "name": "Buriza-Do Kyanon"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/bakkan-caster",
-    "url_name": "bakkan-caster",
-    "api_url": "https://us.battle.net/api/d3/data/item/bakkan-caster",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_xbow_006_x1_demonhunter_male.png",
-    "type": "crossbow",
-    "quality": "legendary",
-    "name": "Bakkan Caster"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/pus-spitter",
-    "url_name": "pus-spitter",
-    "api_url": "https://us.battle.net/api/d3/data/item/pus-spitter",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_xbow_012_x1_demonhunter_male.png",
-    "type": "crossbow",
-    "quality": "legendary",
-    "name": "Pus Spitter"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/starspine",
-    "url_name": "starspine",
-    "api_url": "https://us.battle.net/api/d3/data/item/starspine",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_xbow_004_1xx_demonhunter_male.png",
-    "type": "crossbow",
-    "quality": "legendary",
-    "name": "Starspine"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/hellrack",
-    "url_name": "hellrack",
-    "api_url": "https://us.battle.net/api/d3/data/item/hellrack",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_xbow_002_x1_demonhunter_male.png",
-    "type": "crossbow",
-    "quality": "legendary",
-    "name": "Hellrack"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/manticore",
-    "url_name": "manticore",
-    "api_url": "https://us.battle.net/api/d3/data/item/manticore",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_xbow_001_demonhunter_male.png",
-    "type": "crossbow",
-    "quality": "legendary",
-    "name": "Manticore"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/arcane-barb",
-    "url_name": "arcane-barb",
-    "api_url": "https://us.battle.net/api/d3/data/item/arcane-barb",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_xbow_004_x1_demonhunter_male.png",
-    "type": "crossbow",
-    "quality": "legendary",
-    "name": "Arcane Barb"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/chanon-bolter",
-    "url_name": "chanon-bolter",
-    "api_url": "https://us.battle.net/api/d3/data/item/chanon-bolter",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_xbow_101_x1_demonhunter_male.png",
-    "type": "crossbow",
-    "quality": "legendary",
-    "name": "Chanon Bolter"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/wojahnni-assaulter",
-    "url_name": "wojahnni-assaulter",
-    "api_url": "https://us.battle.net/api/d3/data/item/wojahnni-assaulter",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_xbow_102_x1_demonhunter_male.png",
-    "type": "crossbow",
-    "quality": "legendary",
-    "name": "Wojahnni Assaulter"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/vallas-bequest",
-    "url_name": "vallas-bequest",
-    "api_url": "https://us.battle.net/api/d3/data/item/vallas-bequest",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_handxbow_005_demonhunter_male.png",
-    "type": "hand-crossbow",
-    "quality": "legendary",
-    "name": "Valla's Bequest"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/helltrapper",
-    "url_name": "helltrapper",
-    "api_url": "https://us.battle.net/api/d3/data/item/helltrapper",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_handxbow_102_x1_demonhunter_male.png",
-    "type": "hand-crossbow",
-    "quality": "legendary",
-    "name": "Helltrapper"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/balefire-caster",
-    "url_name": "balefire-caster",
-    "api_url": "https://us.battle.net/api/d3/data/item/balefire-caster",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_handxbow_004_p1_demonhunter_male.png",
-    "type": "hand-crossbow",
-    "quality": "legendary",
-    "name": "Balefire Caster"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/kmar-tenclip",
-    "url_name": "kmar-tenclip",
-    "api_url": "https://us.battle.net/api/d3/data/item/kmar-tenclip",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_handxbow_101_x1_demonhunter_male.png",
-    "type": "hand-crossbow",
-    "quality": "legendary",
-    "name": "K'mar Tenclip"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/deadeye",
-    "url_name": "deadeye",
-    "api_url": "https://us.battle.net/api/d3/data/item/deadeye",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_handxbow_006_1xx_demonhunter_male.png",
-    "type": "hand-crossbow",
-    "quality": "legendary",
-    "name": "Deadeye"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/dawn",
-    "url_name": "dawn",
-    "api_url": "https://us.battle.net/api/d3/data/item/dawn",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_handxbow_001_demonhunter_male.png",
-    "type": "hand-crossbow",
-    "quality": "legendary",
-    "name": "Dawn"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/calamity",
-    "url_name": "calamity",
-    "api_url": "https://us.battle.net/api/d3/data/item/calamity",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_handxbow_012_x1_demonhunter_male.png",
-    "type": "hand-crossbow",
-    "quality": "legendary",
-    "name": "Calamity"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/danettas-revenge",
-    "url_name": "danettas-revenge",
-    "api_url": "https://us.battle.net/api/d3/data/item/danettas-revenge",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_handxbow_002_x1_demonhunter_male.png",
-    "type": "hand-crossbow",
-    "quality": "set",
-    "name": "Danetta's Revenge"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/danettas-spite",
-    "url_name": "danettas-spite",
-    "api_url": "https://us.battle.net/api/d3/data/item/danettas-spite",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_handxbow_001_x1_demonhunter_male.png",
-    "type": "hand-crossbow",
-    "quality": "set",
-    "name": "Danetta's Spite"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/natalyas-slayer",
-    "url_name": "natalyas-slayer",
-    "api_url": "https://us.battle.net/api/d3/data/item/natalyas-slayer",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_handxbow_003_x1_demonhunter_male.png",
-    "type": "hand-crossbow",
-    "quality": "set",
-    "name": "Natalya's Slayer"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-avenger",
-    "url_name": "hallowed-avenger",
-    "api_url": "https://us.battle.net/api/d3/data/item/hallowed-avenger",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_handxbow_016_1xx_demonhunter_male.png",
-    "type": "hand-crossbow",
-    "quality": "set",
-    "name": "Hallowed Judgment"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/blitzbolter",
-    "url_name": "blitzbolter",
-    "api_url": "https://us.battle.net/api/d3/data/item/blitzbolter",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_handxbow_006_x1_demonhunter_male.png",
-    "type": "hand-crossbow",
-    "quality": "legendary",
-    "name": "Blitzbolter"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/fortress-ballista",
-    "url_name": "fortress-ballista",
-    "api_url": "https://us.battle.net/api/d3/data/item/fortress-ballista",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_handxbow_02_demonhunter_male.png",
-    "type": "hand-crossbow",
-    "quality": "legendary",
-    "name": "Fortress Ballista"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/liannas-wings",
-    "url_name": "liannas-wings",
-    "api_url": "https://us.battle.net/api/d3/data/item/liannas-wings",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_handxbow_01_demonhunter_male.png",
-    "type": "hand-crossbow",
-    "quality": "legendary",
-    "name": "Lianna's Wings"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/the-demons-demise",
-    "url_name": "the-demons-demise",
-    "api_url": "https://us.battle.net/api/d3/data/item/the-demons-demise",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_handxbow_norm_unique_03_demonhunter_male.png",
-    "type": "hand-crossbow",
-    "quality": "legendary",
-    "name": "The Demon's Demise"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-condemnation",
-    "url_name": "hallowed-condemnation",
-    "api_url": "https://us.battle.net/api/d3/data/item/hallowed-condemnation",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_handxbow_016_x1_demonhunter_male.png",
-    "type": "hand-crossbow",
-    "quality": "set",
-    "name": "Hallowed Condemnation"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/starfire",
-    "url_name": "starfire",
-    "api_url": "https://us.battle.net/api/d3/data/item/starfire",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wand_003_x1_demonhunter_male.png",
-    "type": "wand",
-    "quality": "legendary",
-    "name": "Starfire"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/unstable-scepter",
-    "url_name": "unstable-scepter",
-    "api_url": "https://us.battle.net/api/d3/data/item/unstable-scepter",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p1_wand_norm_unique_02_demonhunter_male.png",
-    "type": "wand",
-    "quality": "legendary",
-    "name": "Unstable Scepter"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/blackhand-key",
-    "url_name": "blackhand-key",
-    "api_url": "https://us.battle.net/api/d3/data/item/blackhand-key",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wand_006_x1_demonhunter_male.png",
-    "type": "wand",
-    "quality": "legendary",
-    "name": "Blackhand Key"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/serpents-sparker",
-    "url_name": "serpents-sparker",
-    "api_url": "https://us.battle.net/api/d3/data/item/serpents-sparker",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wand_102_x1_demonhunter_male.png",
-    "type": "wand",
-    "quality": "legendary",
-    "name": "Serpent's Sparker"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/wand-of-woh",
-    "url_name": "wand-of-woh",
-    "api_url": "https://us.battle.net/api/d3/data/item/wand-of-woh",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wand_101_x1_demonhunter_male.png",
-    "type": "wand",
-    "quality": "legendary",
-    "name": "Wand of Woh"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/fragment-of-destiny",
-    "url_name": "fragment-of-destiny",
-    "api_url": "https://us.battle.net/api/d3/data/item/fragment-of-destiny",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_wand_010_demonhunter_male.png",
-    "type": "wand",
-    "quality": "legendary",
-    "name": "Fragment of Destiny"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/gesture-of-orpheus",
-    "url_name": "gesture-of-orpheus",
-    "api_url": "https://us.battle.net/api/d3/data/item/gesture-of-orpheus",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_wand_002_demonhunter_male.png",
-    "type": "wand",
-    "quality": "legendary",
-    "name": "Gesture of Orpheus"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/sloraks-madness",
-    "url_name": "sloraks-madness",
-    "api_url": "https://us.battle.net/api/d3/data/item/sloraks-madness",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wand_013_x1_demonhunter_male.png",
-    "type": "wand",
-    "quality": "legendary",
-    "name": "Slorak's Madness"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/chantodos-will",
-    "url_name": "chantodos-will",
-    "api_url": "https://us.battle.net/api/d3/data/item/chantodos-will",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wand_012_x1_demonhunter_male.png",
-    "type": "wand",
-    "quality": "set",
-    "name": "Chantodo's Will"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/ruinstoke",
-    "url_name": "ruinstoke",
-    "api_url": "https://us.battle.net/api/d3/data/item/ruinstoke",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wand_009_1xx_demonhunter_male.png",
-    "type": "wand",
-    "quality": "legendary",
-    "name": "Ruinstoke"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-rod",
-    "url_name": "hallowed-rod",
-    "api_url": "https://us.battle.net/api/d3/data/item/hallowed-rod",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wand_018_1xx_demonhunter_male.png",
-    "type": "wand",
-    "quality": "set",
-    "name": "Hallowed Scepter"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/item/aether-walker",
-    "url_name": "aether-walker",
-    "api_url": "https://us.battle.net/api/d3/data/item/aether-walker",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/p1_wand_norm_unique_01_demonhunter_male.png",
-    "type": "wand",
-    "quality": "legendary",
-    "name": "Aether Walker"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/atrophy",
-    "url_name": "atrophy",
-    "api_url": "https://us.battle.net/api/d3/data/item/atrophy",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wand_009_x1_demonhunter_male.png",
-    "type": "wand",
-    "quality": "legendary",
-    "name": "Atrophy"
-  },
-  {
-    "item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-baton",
-    "url_name": "hallowed-baton",
-    "api_url": "https://us.battle.net/api/d3/data/item/hallowed-baton",
-    "img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wand_018_x1_demonhunter_male.png",
-    "type": "wand",
-    "quality": "set",
-    "name": "Hallowed Baton"
-  }
-]
+[{
+	"item_url": "http://us.battle.net/d3/en/item/leorics-crown",
+	"url_name": "leorics-crown",
+	"api_url": "https://us.battle.net/api/d3/data/item/leorics-crown",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_002_p1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "legendary",
+	"name": "Leoric's Crown"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/prides-fall",
+	"url_name": "prides-fall",
+	"api_url": "https://us.battle.net/api/d3/data/item/prides-fall",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_103_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "legendary",
+	"name": "Pride's Fall"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/broken-crown",
+	"url_name": "broken-crown",
+	"api_url": "https://us.battle.net/api/d3/data/item/broken-crown",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_helm_001_demonhunter_male.png",
+	"type": "helm",
+	"quality": "legendary",
+	"name": "Broken Crown"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/cains-laurel",
+	"url_name": "cains-laurel",
+	"api_url": "https://us.battle.net/api/d3/data/item/cains-laurel",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_012_1xx_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Cain's Memory"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/blind-faith",
+	"url_name": "blind-faith",
+	"api_url": "https://us.battle.net/api/d3/data/item/blind-faith",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_007_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "legendary",
+	"name": "Blind Faith"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/deathseers-cowl",
+	"url_name": "deathseers-cowl",
+	"api_url": "https://us.battle.net/api/d3/data/item/deathseers-cowl",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_102_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "legendary",
+	"name": "Deathseer's Cowl"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/visage-of-gunes",
+	"url_name": "visage-of-gunes",
+	"api_url": "https://us.battle.net/api/d3/data/item/visage-of-gunes",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_helm_103_demonhunter_male.png",
+	"type": "helm",
+	"quality": "legendary",
+	"name": "Visage of Gunes"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/warhelm-of-kassar",
+	"url_name": "warhelm-of-kassar",
+	"api_url": "https://us.battle.net/api/d3/data/item/warhelm-of-kassar",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_helm_102_demonhunter_male.png",
+	"type": "helm",
+	"quality": "legendary",
+	"name": "Warhelm of Kassar"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/aughilds-brow",
+	"url_name": "aughilds-brow",
+	"api_url": "https://us.battle.net/api/d3/data/item/aughilds-brow",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_014_1xx_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Aughild's Peak"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/skull-of-resonance",
+	"url_name": "skull-of-resonance",
+	"api_url": "https://us.battle.net/api/d3/data/item/skull-of-resonance",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_004_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "legendary",
+	"name": "Skull of Resonance"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/guardians-watch",
+	"url_name": "guardians-watch",
+	"api_url": "https://us.battle.net/api/d3/data/item/guardians-watch",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_015_1xx_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Guardian's Foresight"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/andariels-visage",
+	"url_name": "andariels-visage",
+	"api_url": "https://us.battle.net/api/d3/data/item/andariels-visage",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_003_p2_demonhunter_male.png",
+	"type": "helm",
+	"quality": "legendary",
+	"name": "Andariel's Visage"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/mempo-of-twilight",
+	"url_name": "mempo-of-twilight",
+	"api_url": "https://us.battle.net/api/d3/data/item/mempo-of-twilight",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_006_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "legendary",
+	"name": "Mempo of Twilight"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/immortal-kings-triumph",
+	"url_name": "immortal-kings-triumph",
+	"api_url": "https://us.battle.net/api/d3/data/item/immortal-kings-triumph",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_008_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Immortal King's Triumph"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/natalyas-sight",
+	"url_name": "natalyas-sight",
+	"api_url": "https://us.battle.net/api/d3/data/item/natalyas-sight",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_009_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Natalya's Sight"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/tal-rashas-guise-of-wisdom",
+	"url_name": "tal-rashas-guise-of-wisdom",
+	"api_url": "https://us.battle.net/api/d3/data/item/tal-rashas-guise-of-wisdom",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_010_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Tal Rasha's Guise of Wisdom"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/the-helm-of-command",
+	"url_name": "the-helm-of-command",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-helm-of-command",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_011_1xx_demonhunter_male.png",
+	"type": "helm",
+	"quality": "legendary",
+	"name": "The Helm of Command"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/sages-stones",
+	"url_name": "sages-stones",
+	"api_url": "https://us.battle.net/api/d3/data/item/sages-stones",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_016_1xx_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Sage's Orbit"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/the-helm-of-rule",
+	"url_name": "the-helm-of-rule",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-helm-of-rule",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_011_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "legendary",
+	"name": "The Helm of Rule"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/accursed-visage",
+	"url_name": "accursed-visage",
+	"api_url": "https://us.battle.net/api/d3/data/item/accursed-visage",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_03_p2_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Accursed Visage"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/arachyrs-visage",
+	"url_name": "arachyrs-visage",
+	"api_url": "https://us.battle.net/api/d3/data/item/arachyrs-visage",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_02_p3_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Arachyr’s Visage"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/aughilds-spike",
+	"url_name": "aughilds-spike",
+	"api_url": "https://us.battle.net/api/d3/data/item/aughilds-spike",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_014_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Aughild's Spike"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/cains-insight",
+	"url_name": "cains-insight",
+	"api_url": "https://us.battle.net/api/d3/data/item/cains-insight",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_012_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Cain's Insight"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/crown-of-the-invoker",
+	"url_name": "crown-of-the-invoker",
+	"api_url": "https://us.battle.net/api/d3/data/item/crown-of-the-invoker",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_12_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Crown of the Invoker"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/crown-of-the-light",
+	"url_name": "crown-of-the-light",
+	"api_url": "https://us.battle.net/api/d3/data/item/crown-of-the-light",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_03_p3_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Crown of the Light"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/eyes-of-the-earth",
+	"url_name": "eyes-of-the-earth",
+	"api_url": "https://us.battle.net/api/d3/data/item/eyes-of-the-earth",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_15_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Eyes of the Earth"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/firebirds-plume",
+	"url_name": "firebirds-plume",
+	"api_url": "https://us.battle.net/api/d3/data/item/firebirds-plume",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_06_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Firebird's Plume"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/guardians-gaze",
+	"url_name": "guardians-gaze",
+	"api_url": "https://us.battle.net/api/d3/data/item/guardians-gaze",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_015_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Guardian's Gaze"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/helltooth-mask",
+	"url_name": "helltooth-mask",
+	"api_url": "https://us.battle.net/api/d3/data/item/helltooth-mask",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_16_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Helltooth Mask"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/helm-of-akkhan",
+	"url_name": "helm-of-akkhan",
+	"api_url": "https://us.battle.net/api/d3/data/item/helm-of-akkhan",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_10_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Helm of Akkhan"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/helm-of-the-wastes",
+	"url_name": "helm-of-the-wastes",
+	"api_url": "https://us.battle.net/api/d3/data/item/helm-of-the-wastes",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_01_p2_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Helm of the Wastes"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/jade-harvesters-wisdom",
+	"url_name": "jade-harvesters-wisdom",
+	"api_url": "https://us.battle.net/api/d3/data/item/jade-harvesters-wisdom",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_09_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Jade Harvester's Wisdom"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/marauders-visage",
+	"url_name": "marauders-visage",
+	"api_url": "https://us.battle.net/api/d3/data/item/marauders-visage",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_07_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Marauder's Visage"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/mask-of-the-searing-sky",
+	"url_name": "mask-of-the-searing-sky",
+	"api_url": "https://us.battle.net/api/d3/data/item/mask-of-the-searing-sky",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_08_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Mask of the Searing Sky"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/raekors-will",
+	"url_name": "raekors-will",
+	"api_url": "https://us.battle.net/api/d3/data/item/raekors-will",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_05_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Raekor's Will"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/rolands-visage",
+	"url_name": "rolands-visage",
+	"api_url": "https://us.battle.net/api/d3/data/item/rolands-visage",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_01_p1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Roland's Visage"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/sages-apogee",
+	"url_name": "sages-apogee",
+	"api_url": "https://us.battle.net/api/d3/data/item/sages-apogee",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_016_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Sage's Apogee"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/shrouded-mask",
+	"url_name": "shrouded-mask",
+	"api_url": "https://us.battle.net/api/d3/data/item/shrouded-mask",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_02_p2_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Shrouded Mask"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/sunwukos-crown",
+	"url_name": "sunwukos-crown",
+	"api_url": "https://us.battle.net/api/d3/data/item/sunwukos-crown",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_11_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Sunwuko's Crown"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-shadows-mask",
+	"url_name": "the-shadows-mask",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-shadows-mask",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_14_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "The Shadow's Mask"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/ulianas-spirit",
+	"url_name": "ulianas-spirit",
+	"api_url": "https://us.battle.net/api/d3/data/item/ulianas-spirit",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_01_p3_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Uliana's Spirit"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/vyrs-sightless-skull",
+	"url_name": "vyrs-sightless-skull",
+	"api_url": "https://us.battle.net/api/d3/data/item/vyrs-sightless-skull",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_helm_set_13_x1_demonhunter_male.png",
+	"type": "helm",
+	"quality": "set",
+	"name": "Vyr's Sightless Skull"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/see-no-evil",
+	"url_name": "see-no-evil",
+	"api_url": "https://us.battle.net/api/d3/data/item/see-no-evil",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spiritstone_005_x1_demonhunter_male.png",
+	"type": "spirit-stone",
+	"quality": "legendary",
+	"name": "See No Evil"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/gyana-na-kashu",
+	"url_name": "gyana-na-kashu",
+	"api_url": "https://us.battle.net/api/d3/data/item/gyana-na-kashu",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spiritstone_004_x1_demonhunter_male.png",
+	"type": "spirit-stone",
+	"quality": "legendary",
+	"name": "Gyana Na Kashu"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/erlang-shen",
+	"url_name": "erlang-shen",
+	"api_url": "https://us.battle.net/api/d3/data/item/erlang-shen",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spiritstone_003_x1_demonhunter_male.png",
+	"type": "spirit-stone",
+	"quality": "legendary",
+	"name": "Erlang Shen"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-minds-eye",
+	"url_name": "the-minds-eye",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-minds-eye",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spiritstone_002_x1_demonhunter_male.png",
+	"type": "spirit-stone",
+	"quality": "legendary",
+	"name": "The Mind's Eye"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/eye-of-peshkov",
+	"url_name": "eye-of-peshkov",
+	"api_url": "https://us.battle.net/api/d3/data/item/eye-of-peshkov",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spiritstone_103_x1_demonhunter_male.png",
+	"type": "spirit-stone",
+	"quality": "legendary",
+	"name": "Eye of Peshkov"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/kekegis-unbreakable-spirit",
+	"url_name": "kekegis-unbreakable-spirit",
+	"api_url": "https://us.battle.net/api/d3/data/item/kekegis-unbreakable-spirit",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spiritstone_102_x1_demonhunter_male.png",
+	"type": "spirit-stone",
+	"quality": "legendary",
+	"name": "Kekegi's Unbreakable Spirit"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-laws-of-seph",
+	"url_name": "the-laws-of-seph",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-laws-of-seph",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spiritstone_101_x1_demonhunter_male.png",
+	"type": "spirit-stone",
+	"quality": "legendary",
+	"name": "The Laws of Seph"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/bezoar-stone",
+	"url_name": "bezoar-stone",
+	"api_url": "https://us.battle.net/api/d3/data/item/bezoar-stone",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spiritstone_001_x1_demonhunter_male.png",
+	"type": "spirit-stone",
+	"quality": "legendary",
+	"name": "Bezoar Stone"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-eye-of-the-storm",
+	"url_name": "the-eye-of-the-storm",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-eye-of-the-storm",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spiritstone_006_x1_demonhunter_male.png",
+	"type": "spirit-stone",
+	"quality": "legendary",
+	"name": "The Eye of the Storm"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/madstone",
+	"url_name": "madstone",
+	"api_url": "https://us.battle.net/api/d3/data/item/madstone",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p1_unique_spiritstone_008_demonhunter_male.png",
+	"type": "spirit-stone",
+	"quality": "legendary",
+	"name": "Madstone"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/tzo-krins-gaze",
+	"url_name": "tzo-krins-gaze",
+	"api_url": "https://us.battle.net/api/d3/data/item/tzo-krins-gaze",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spiritstone_007_x1_demonhunter_male.png",
+	"type": "spirit-stone",
+	"quality": "legendary",
+	"name": "Tzo Krin's Gaze"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/innas-radiance",
+	"url_name": "innas-radiance",
+	"api_url": "https://us.battle.net/api/d3/data/item/innas-radiance",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spiritstone_009_x1_demonhunter_male.png",
+	"type": "spirit-stone",
+	"quality": "set",
+	"name": "Inna's Radiance"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/split-tusk",
+	"url_name": "split-tusk",
+	"api_url": "https://us.battle.net/api/d3/data/item/split-tusk",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_voodoomask_006_x1_demonhunter_male.png",
+	"type": "voodoo-mask",
+	"quality": "legendary",
+	"name": "Split Tusk"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/quetzalcoatl",
+	"url_name": "quetzalcoatl",
+	"api_url": "https://us.battle.net/api/d3/data/item/quetzalcoatl",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_voodoomask_005_x1_demonhunter_male.png",
+	"type": "voodoo-mask",
+	"quality": "legendary",
+	"name": "Quetzalcoatl"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/carnevil",
+	"url_name": "carnevil",
+	"api_url": "https://us.battle.net/api/d3/data/item/carnevil",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_voodoomask_101_x1_demonhunter_male.png",
+	"type": "voodoo-mask",
+	"quality": "legendary",
+	"name": "Carnevil"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/mask-of-jeram",
+	"url_name": "mask-of-jeram",
+	"api_url": "https://us.battle.net/api/d3/data/item/mask-of-jeram",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_voodoomask_102_x1_demonhunter_male.png",
+	"type": "voodoo-mask",
+	"quality": "legendary",
+	"name": "Mask of Jeram"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-grin-reaper",
+	"url_name": "the-grin-reaper",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-grin-reaper",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_voodoomask_002_x1_demonhunter_male.png",
+	"type": "voodoo-mask",
+	"quality": "legendary",
+	"name": "The Grin Reaper"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/tiklandian-visage",
+	"url_name": "tiklandian-visage",
+	"api_url": "https://us.battle.net/api/d3/data/item/tiklandian-visage",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_voodoomask_001_x1_demonhunter_male.png",
+	"type": "voodoo-mask",
+	"quality": "legendary",
+	"name": "Tiklandian Visage"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/visage-of-giyua",
+	"url_name": "visage-of-giyua",
+	"api_url": "https://us.battle.net/api/d3/data/item/visage-of-giyua",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_voodoomask_008_x1_demonhunter_male.png",
+	"type": "voodoo-mask",
+	"quality": "legendary",
+	"name": "Visage of Giyua"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/zunimassas-vision",
+	"url_name": "zunimassas-vision",
+	"api_url": "https://us.battle.net/api/d3/data/item/zunimassas-vision",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_voodoomask_007_x1_demonhunter_male.png",
+	"type": "voodoo-mask",
+	"quality": "set",
+	"name": "Zunimassa's Vision"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/crown-of-the-primus",
+	"url_name": "crown-of-the-primus",
+	"api_url": "https://us.battle.net/api/d3/data/item/crown-of-the-primus",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wizardhat_104_x1_demonhunter_male.png",
+	"type": "wizard-hat",
+	"quality": "legendary",
+	"name": "Crown of the Primus"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-swami",
+	"url_name": "the-swami",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-swami",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_wizardhat_003_demonhunter_male.png",
+	"type": "wizard-hat",
+	"quality": "legendary",
+	"name": "The Swami"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/dark-mages-shade",
+	"url_name": "dark-mages-shade",
+	"api_url": "https://us.battle.net/api/d3/data/item/dark-mages-shade",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wizardhat_001_x1_demonhunter_male.png",
+	"type": "wizard-hat",
+	"quality": "legendary",
+	"name": "Dark Mage's Shade"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/archmages-vicalyke",
+	"url_name": "archmages-vicalyke",
+	"api_url": "https://us.battle.net/api/d3/data/item/archmages-vicalyke",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wizardhat_101_x1_demonhunter_male.png",
+	"type": "wizard-hat",
+	"quality": "legendary",
+	"name": "Archmage's Vicalyke"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-magistrate",
+	"url_name": "the-magistrate",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-magistrate",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wizardhat_103_x1_demonhunter_male.png",
+	"type": "wizard-hat",
+	"quality": "legendary",
+	"name": "The Magistrate"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/velvet-camaral",
+	"url_name": "velvet-camaral",
+	"api_url": "https://us.battle.net/api/d3/data/item/velvet-camaral",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wizardhat_102_x1_demonhunter_male.png",
+	"type": "wizard-hat",
+	"quality": "legendary",
+	"name": "Velvet Camaral"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/storm-crow",
+	"url_name": "storm-crow",
+	"api_url": "https://us.battle.net/api/d3/data/item/storm-crow",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wizardhat_004_x1_demonhunter_male.png",
+	"type": "wizard-hat",
+	"quality": "legendary",
+	"name": "Storm Crow"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/homing-pads",
+	"url_name": "homing-pads",
+	"api_url": "https://us.battle.net/api/d3/data/item/homing-pads",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_001_x1_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "legendary",
+	"name": "Homing Pads"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/pauldrons-of-the-skeleton-king",
+	"url_name": "pauldrons-of-the-skeleton-king",
+	"api_url": "https://us.battle.net/api/d3/data/item/pauldrons-of-the-skeleton-king",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_103_x1_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "legendary",
+	"name": "Pauldrons of the Skeleton King"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/borns-pauldrons",
+	"url_name": "borns-pauldrons",
+	"api_url": "https://us.battle.net/api/d3/data/item/borns-pauldrons",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_006_1xx_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Born's Impunity"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/death-watch-mantle",
+	"url_name": "death-watch-mantle",
+	"api_url": "https://us.battle.net/api/d3/data/item/death-watch-mantle",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_002_p2_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "legendary",
+	"name": "Death Watch Mantle"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/fury-of-the-ancients",
+	"url_name": "fury-of-the-ancients",
+	"api_url": "https://us.battle.net/api/d3/data/item/fury-of-the-ancients",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_shoulder_102_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "legendary",
+	"name": "Fury of the Ancients"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/lefebvres-soliloquy",
+	"url_name": "lefebvres-soliloquy",
+	"api_url": "https://us.battle.net/api/d3/data/item/lefebvres-soliloquy",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_shoulder_101_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "legendary",
+	"name": "Lefebvre’s Soliloquy"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/mantle-of-channeling",
+	"url_name": "mantle-of-channeling",
+	"api_url": "https://us.battle.net/api/d3/data/item/mantle-of-channeling",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_shoulder_103_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "legendary",
+	"name": "Mantle of Channeling"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/spaulders-of-zakara",
+	"url_name": "spaulders-of-zakara",
+	"api_url": "https://us.battle.net/api/d3/data/item/spaulders-of-zakara",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_102_x1_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "legendary",
+	"name": "Spaulders of Zakara"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/aughilds-triumph",
+	"url_name": "aughilds-triumph",
+	"api_url": "https://us.battle.net/api/d3/data/item/aughilds-triumph",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_008_1xx_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Aughild's Reign"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/ashearas-vigilance",
+	"url_name": "ashearas-vigilance",
+	"api_url": "https://us.battle.net/api/d3/data/item/ashearas-vigilance",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_017_1xx_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Asheara's Guard"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/vile-ward",
+	"url_name": "vile-ward",
+	"api_url": "https://us.battle.net/api/d3/data/item/vile-ward",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_003_p1_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "legendary",
+	"name": "Vile Ward"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/seven-sins",
+	"url_name": "seven-sins",
+	"api_url": "https://us.battle.net/api/d3/data/item/seven-sins",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_007_1xx_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "legendary",
+	"name": "Seven Sins"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demons-wings",
+	"url_name": "demons-wings",
+	"api_url": "https://us.battle.net/api/d3/data/item/demons-wings",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_009_1xx_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Demon's Flight"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/corruption",
+	"url_name": "corruption",
+	"api_url": "https://us.battle.net/api/d3/data/item/corruption",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_007_x1_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "legendary",
+	"name": "Corruption"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/arachyrs-mantle",
+	"url_name": "arachyrs-mantle",
+	"api_url": "https://us.battle.net/api/d3/data/item/arachyrs-mantle",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_02_p3_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Arachyr’s Mantle"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/ashearas-custodian",
+	"url_name": "ashearas-custodian",
+	"api_url": "https://us.battle.net/api/d3/data/item/ashearas-custodian",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_017_x1_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Asheara's Custodian"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/aughilds-power",
+	"url_name": "aughilds-power",
+	"api_url": "https://us.battle.net/api/d3/data/item/aughilds-power",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_008_x1_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Aughild's Power"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/borns-privilege",
+	"url_name": "borns-privilege",
+	"api_url": "https://us.battle.net/api/d3/data/item/borns-privilege",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_006_x1_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Born's Privilege"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/burden-of-the-invoker",
+	"url_name": "burden-of-the-invoker",
+	"api_url": "https://us.battle.net/api/d3/data/item/burden-of-the-invoker",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_12_x1_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Burden of the Invoker"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/dashing-pauldrons-of-despair",
+	"url_name": "dashing-pauldrons-of-despair",
+	"api_url": "https://us.battle.net/api/d3/data/item/dashing-pauldrons-of-despair",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_02_p2_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Dashing Pauldrons of Despair"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demons-aileron",
+	"url_name": "demons-aileron",
+	"api_url": "https://us.battle.net/api/d3/data/item/demons-aileron",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_009_x1_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Demon's Aileron"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/firebirds-pinions",
+	"url_name": "firebirds-pinions",
+	"api_url": "https://us.battle.net/api/d3/data/item/firebirds-pinions",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_06_x1_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Firebird's Pinions"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/helltooth-mantle",
+	"url_name": "helltooth-mantle",
+	"api_url": "https://us.battle.net/api/d3/data/item/helltooth-mantle",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_16_x1_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Helltooth Mantle"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/jade-harvesters-joy",
+	"url_name": "jade-harvesters-joy",
+	"api_url": "https://us.battle.net/api/d3/data/item/jade-harvesters-joy",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_09_x1_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Jade Harvester's Joy"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/mantle-of-the-upsidedown-sinners",
+	"url_name": "mantle-of-the-upsidedown-sinners",
+	"api_url": "https://us.battle.net/api/d3/data/item/mantle-of-the-upsidedown-sinners",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_08_x1_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Mantle of the Upside-Down Sinners"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/marauders-spines",
+	"url_name": "marauders-spines",
+	"api_url": "https://us.battle.net/api/d3/data/item/marauders-spines",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_07_x1_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Marauder's Spines"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/mountain-of-the-light",
+	"url_name": "mountain-of-the-light",
+	"api_url": "https://us.battle.net/api/d3/data/item/mountain-of-the-light",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_03_p3_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Mountain of the Light"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/pauldrons-of-akkhan",
+	"url_name": "pauldrons-of-akkhan",
+	"api_url": "https://us.battle.net/api/d3/data/item/pauldrons-of-akkhan",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_10_x1_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Pauldrons of Akkhan"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/pauldrons-of-the-wastes",
+	"url_name": "pauldrons-of-the-wastes",
+	"api_url": "https://us.battle.net/api/d3/data/item/pauldrons-of-the-wastes",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_01_p2_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Pauldrons of the Wastes"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/raekors-burden",
+	"url_name": "raekors-burden",
+	"api_url": "https://us.battle.net/api/d3/data/item/raekors-burden",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_05_x1_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Raekor's Burden"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/rolands-mantle",
+	"url_name": "rolands-mantle",
+	"api_url": "https://us.battle.net/api/d3/data/item/rolands-mantle",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_01_p1_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Roland's Mantle"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/spires-of-the-earth",
+	"url_name": "spires-of-the-earth",
+	"api_url": "https://us.battle.net/api/d3/data/item/spires-of-the-earth",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_15_x1_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Spires of the Earth"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/sunwukos-balance",
+	"url_name": "sunwukos-balance",
+	"api_url": "https://us.battle.net/api/d3/data/item/sunwukos-balance",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_11_x1_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Sunwuko's Balance"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-shadows-burden",
+	"url_name": "the-shadows-burden",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-shadows-burden",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_14_x1_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "The Shadow's Burden"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/ulianas-strength",
+	"url_name": "ulianas-strength",
+	"api_url": "https://us.battle.net/api/d3/data/item/ulianas-strength",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_01_p3_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Uliana's Strength"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/unsanctified-shoulders",
+	"url_name": "unsanctified-shoulders",
+	"api_url": "https://us.battle.net/api/d3/data/item/unsanctified-shoulders",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_03_p2_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Unsanctified Shoulders"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/vyrs-proud-pauldrons",
+	"url_name": "vyrs-proud-pauldrons",
+	"api_url": "https://us.battle.net/api/d3/data/item/vyrs-proud-pauldrons",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shoulder_set_13_x1_demonhunter_male.png",
+	"type": "pauldrons",
+	"quality": "set",
+	"name": "Vyr's Proud Pauldrons"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/heart-of-iron",
+	"url_name": "heart-of-iron",
+	"api_url": "https://us.battle.net/api/d3/data/item/heart-of-iron",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_chest_018_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "legendary",
+	"name": "Heart of Iron"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/aquila-cuirass",
+	"url_name": "aquila-cuirass",
+	"api_url": "https://us.battle.net/api/d3/data/item/aquila-cuirass",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_chest_012_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "legendary",
+	"name": "Aquila Cuirass"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/borns-carapace",
+	"url_name": "borns-carapace",
+	"api_url": "https://us.battle.net/api/d3/data/item/borns-carapace",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_025_1xx_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Born's Heart of Steel"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/chaingmail",
+	"url_name": "chaingmail",
+	"api_url": "https://us.battle.net/api/d3/data/item/chaingmail",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_010_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "legendary",
+	"name": "Chaingmail"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/cindercoat",
+	"url_name": "cindercoat",
+	"api_url": "https://us.battle.net/api/d3/data/item/cindercoat",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_006_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "legendary",
+	"name": "Cindercoat"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/shi-mizus-haori",
+	"url_name": "shi-mizus-haori",
+	"api_url": "https://us.battle.net/api/d3/data/item/shi-mizus-haori",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_101_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "legendary",
+	"name": "Shi Mizu's Haori"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/aughilds-vestments",
+	"url_name": "aughilds-vestments",
+	"api_url": "https://us.battle.net/api/d3/data/item/aughilds-vestments",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_026_1xx_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Aughild's Dominion"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/goldskin",
+	"url_name": "goldskin",
+	"api_url": "https://us.battle.net/api/d3/data/item/goldskin",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_001_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "legendary",
+	"name": "Goldskin"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/tyraels-might",
+	"url_name": "tyraels-might",
+	"api_url": "https://us.battle.net/api/d3/data/item/tyraels-might",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_002_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "legendary",
+	"name": "Tyrael's Might"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/blackthornes-surcoat",
+	"url_name": "blackthornes-surcoat",
+	"api_url": "https://us.battle.net/api/d3/data/item/blackthornes-surcoat",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chestarmor_028_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Blackthorne's Surcoat"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/immortal-kings-eternal-reign",
+	"url_name": "immortal-kings-eternal-reign",
+	"api_url": "https://us.battle.net/api/d3/data/item/immortal-kings-eternal-reign",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_013_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Immortal King's Eternal Reign"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/innas-vast-expanse",
+	"url_name": "innas-vast-expanse",
+	"api_url": "https://us.battle.net/api/d3/data/item/innas-vast-expanse",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_015_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Inna's Vast Expanse"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/tal-rashas-relentless-pursuit",
+	"url_name": "tal-rashas-relentless-pursuit",
+	"api_url": "https://us.battle.net/api/d3/data/item/tal-rashas-relentless-pursuit",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_014_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Tal Rasha's Relentless Pursuit"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/zunimassas-marrow",
+	"url_name": "zunimassas-marrow",
+	"api_url": "https://us.battle.net/api/d3/data/item/zunimassas-marrow",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_016_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Zunimassa's Marrow"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/robes-of-the-rydraelm",
+	"url_name": "robes-of-the-rydraelm",
+	"api_url": "https://us.battle.net/api/d3/data/item/robes-of-the-rydraelm",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_019_1xx_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "legendary",
+	"name": "Robes of the Rydraelm"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demons-cage",
+	"url_name": "demons-cage",
+	"api_url": "https://us.battle.net/api/d3/data/item/demons-cage",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_027_1xx_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Demon's Heart"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/armor-of-the-kind-regent",
+	"url_name": "armor-of-the-kind-regent",
+	"api_url": "https://us.battle.net/api/d3/data/item/armor-of-the-kind-regent",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_102_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "legendary",
+	"name": "Armor of the Kind Regent"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/mantle-of-the-rydraelm",
+	"url_name": "mantle-of-the-rydraelm",
+	"api_url": "https://us.battle.net/api/d3/data/item/mantle-of-the-rydraelm",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_019_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "legendary",
+	"name": "Mantle of the Rydraelm"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/arachyrs-carapace",
+	"url_name": "arachyrs-carapace",
+	"api_url": "https://us.battle.net/api/d3/data/item/arachyrs-carapace",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_02_p3_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Arachyr’s Carapace"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/aughilds-rule",
+	"url_name": "aughilds-rule",
+	"api_url": "https://us.battle.net/api/d3/data/item/aughilds-rule",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_026_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Aughild's Rule"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/borns-frozen-soul",
+	"url_name": "borns-frozen-soul",
+	"api_url": "https://us.battle.net/api/d3/data/item/borns-frozen-soul",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_025_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Born's Frozen Soul"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/breastplate-of-akkhan",
+	"url_name": "breastplate-of-akkhan",
+	"api_url": "https://us.battle.net/api/d3/data/item/breastplate-of-akkhan",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_10_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Breastplate of Akkhan"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/cuirass-of-the-wastes",
+	"url_name": "cuirass-of-the-wastes",
+	"api_url": "https://us.battle.net/api/d3/data/item/cuirass-of-the-wastes",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_01_p2_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Cuirass of the Wastes"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demons-marrow",
+	"url_name": "demons-marrow",
+	"api_url": "https://us.battle.net/api/d3/data/item/demons-marrow",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_027_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Demon's Marrow"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/firebirds-breast",
+	"url_name": "firebirds-breast",
+	"api_url": "https://us.battle.net/api/d3/data/item/firebirds-breast",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_06_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Firebird's Breast"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/harness-of-truth",
+	"url_name": "harness-of-truth",
+	"api_url": "https://us.battle.net/api/d3/data/item/harness-of-truth",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_02_p2_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Harness of Truth"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/heart-of-the-crashing-wave",
+	"url_name": "heart-of-the-crashing-wave",
+	"api_url": "https://us.battle.net/api/d3/data/item/heart-of-the-crashing-wave",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_08_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Heart of the Crashing Wave"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/heart-of-the-light",
+	"url_name": "heart-of-the-light",
+	"api_url": "https://us.battle.net/api/d3/data/item/heart-of-the-light",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_03_p3_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Heart of the Light"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/helltooth-tunic",
+	"url_name": "helltooth-tunic",
+	"api_url": "https://us.battle.net/api/d3/data/item/helltooth-tunic",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_16_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Helltooth Tunic"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/jade-harvesters-peace",
+	"url_name": "jade-harvesters-peace",
+	"api_url": "https://us.battle.net/api/d3/data/item/jade-harvesters-peace",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_09_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Jade Harvester's Peace"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/marauders-carapace",
+	"url_name": "marauders-carapace",
+	"api_url": "https://us.battle.net/api/d3/data/item/marauders-carapace",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_07_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Marauder's Carapace"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/raekors-heart",
+	"url_name": "raekors-heart",
+	"api_url": "https://us.battle.net/api/d3/data/item/raekors-heart",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_05_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Raekor's Heart"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/rolands-bearing",
+	"url_name": "rolands-bearing",
+	"api_url": "https://us.battle.net/api/d3/data/item/rolands-bearing",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_01_p1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Roland's Bearing"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/spirit-of-the-earth",
+	"url_name": "spirit-of-the-earth",
+	"api_url": "https://us.battle.net/api/d3/data/item/spirit-of-the-earth",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_15_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Spirit of the Earth"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/sunwukos-soul",
+	"url_name": "sunwukos-soul",
+	"api_url": "https://us.battle.net/api/d3/data/item/sunwukos-soul",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_11_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Sunwuko's Soul"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-shadows-bane",
+	"url_name": "the-shadows-bane",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-shadows-bane",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_14_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "The Shadow's Bane"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/ulianas-heart",
+	"url_name": "ulianas-heart",
+	"api_url": "https://us.battle.net/api/d3/data/item/ulianas-heart",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_01_p3_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Uliana's Heart"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/vyrs-astonishing-aura",
+	"url_name": "vyrs-astonishing-aura",
+	"api_url": "https://us.battle.net/api/d3/data/item/vyrs-astonishing-aura",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_13_x1_demonhunter_male.png",
+	"type": "chest-armor",
+	"quality": "set",
+	"name": "Vyr's Astonishing Aura"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/cloak-of-deception",
+	"url_name": "cloak-of-deception",
+	"api_url": "https://us.battle.net/api/d3/data/item/cloak-of-deception",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_cloak_102_x1_demonhunter_male.png",
+	"type": "cloak",
+	"quality": "legendary",
+	"name": "Cloak of Deception"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/beckon-sail",
+	"url_name": "beckon-sail",
+	"api_url": "https://us.battle.net/api/d3/data/item/beckon-sail",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_cloak_005_x1_demonhunter_male.png",
+	"type": "cloak",
+	"quality": "legendary",
+	"name": "Beckon Sail"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/blackfeather",
+	"url_name": "blackfeather",
+	"api_url": "https://us.battle.net/api/d3/data/item/blackfeather",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_cloak_101_x1_demonhunter_male.png",
+	"type": "cloak",
+	"quality": "legendary",
+	"name": "Blackfeather"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/cape-of-the-dark-night",
+	"url_name": "cape-of-the-dark-night",
+	"api_url": "https://us.battle.net/api/d3/data/item/cape-of-the-dark-night",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_cloak_001_x1_demonhunter_male.png",
+	"type": "cloak",
+	"quality": "legendary",
+	"name": "Cape of the Dark Night"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-cloak-of-the-garwulf",
+	"url_name": "the-cloak-of-the-garwulf",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-cloak-of-the-garwulf",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_cloak_002_p1_demonhunter_male.png",
+	"type": "cloak",
+	"quality": "legendary",
+	"name": "The Cloak of the Garwulf"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/natalyas-embrace",
+	"url_name": "natalyas-embrace",
+	"api_url": "https://us.battle.net/api/d3/data/item/natalyas-embrace",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_cloak_006_x1_demonhunter_male.png",
+	"type": "cloak",
+	"quality": "set",
+	"name": "Natalya's Embrace"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/cage-of-the-hellborn",
+	"url_name": "cage-of-the-hellborn",
+	"api_url": "https://us.battle.net/api/d3/data/item/cage-of-the-hellborn",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_chest_set_03_p2_demonhunter_male.png",
+	"type": "cloak",
+	"quality": "set",
+	"name": "Cage of the Hellborn"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/ashnagarrs-blood-bracer",
+	"url_name": "ashnagarrs-blood-bracer",
+	"api_url": "https://us.battle.net/api/d3/data/item/ashnagarrs-blood-bracer",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_bracer_004_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Ashnagarr’s Blood Bracer"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/cesars-memento",
+	"url_name": "cesars-memento",
+	"api_url": "https://us.battle.net/api/d3/data/item/cesars-memento",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_bracer_107_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Cesar’s Memento"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/gungdo-gear",
+	"url_name": "gungdo-gear",
+	"api_url": "https://us.battle.net/api/d3/data/item/gungdo-gear",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_bracer_006_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Gungdo Gear"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/bracers-of-destruction",
+	"url_name": "bracers-of-destruction",
+	"api_url": "https://us.battle.net/api/d3/data/item/bracers-of-destruction",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_bracer_104_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Bracers of Destruction"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/bracers-of-the-first-men",
+	"url_name": "bracers-of-the-first-men",
+	"api_url": "https://us.battle.net/api/d3/data/item/bracers-of-the-first-men",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_bracer_105_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Bracers of the First Men"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/gabriels-vambraces",
+	"url_name": "gabriels-vambraces",
+	"api_url": "https://us.battle.net/api/d3/data/item/gabriels-vambraces",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_bracer_101_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Gabriel's Vambraces"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/jerams-bracers",
+	"url_name": "jerams-bracers",
+	"api_url": "https://us.battle.net/api/d3/data/item/jerams-bracers",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_bracer_106_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Jeram's Bracers"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/pintos-pride",
+	"url_name": "pintos-pride",
+	"api_url": "https://us.battle.net/api/d3/data/item/pintos-pride",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_bracer_105_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Pinto's Pride"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/sanguinary-vambraces",
+	"url_name": "sanguinary-vambraces",
+	"api_url": "https://us.battle.net/api/d3/data/item/sanguinary-vambraces",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_105_x1_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Sanguinary Vambraces"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/wraps-of-clarity",
+	"url_name": "wraps-of-clarity",
+	"api_url": "https://us.battle.net/api/d3/data/item/wraps-of-clarity",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_bracer_103_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Wraps of Clarity"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/bindings-of-the-lesser-gods",
+	"url_name": "bindings-of-the-lesser-gods",
+	"api_url": "https://us.battle.net/api/d3/data/item/bindings-of-the-lesser-gods",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_bracer_108_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Bindings of the Lesser Gods"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/akkhans-manacles",
+	"url_name": "akkhans-manacles",
+	"api_url": "https://us.battle.net/api/d3/data/item/akkhans-manacles",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_bracer_103_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Akkhan’s Manacles"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/bracer-of-fury",
+	"url_name": "bracer-of-fury",
+	"api_url": "https://us.battle.net/api/d3/data/item/bracer-of-fury",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_bracer_104_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Bracer of Fury"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/vambraces-of-sescheron",
+	"url_name": "vambraces-of-sescheron",
+	"api_url": "https://us.battle.net/api/d3/data/item/vambraces-of-sescheron",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_bracer_106_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Vambraces of Sescheron"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/ancient-parthan-defenders",
+	"url_name": "ancient-parthan-defenders",
+	"api_url": "https://us.battle.net/api/d3/data/item/ancient-parthan-defenders",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_102_x1_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Ancient Parthan Defenders"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/custerian-wristguards",
+	"url_name": "custerian-wristguards",
+	"api_url": "https://us.battle.net/api/d3/data/item/custerian-wristguards",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_107_x1_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Custerian Wristguards"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/nemesis-bracers",
+	"url_name": "nemesis-bracers",
+	"api_url": "https://us.battle.net/api/d3/data/item/nemesis-bracers",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_106_x1_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Nemesis Bracers"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/warzechian-armguards",
+	"url_name": "warzechian-armguards",
+	"api_url": "https://us.battle.net/api/d3/data/item/warzechian-armguards",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_101_x1_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Warzechian Armguards"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/aughilds-demands",
+	"url_name": "aughilds-demands",
+	"api_url": "https://us.battle.net/api/d3/data/item/aughilds-demands",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_009_1xx_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "set",
+	"name": "Aughild's Ultimatum"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/promise-of-glory",
+	"url_name": "promise-of-glory",
+	"api_url": "https://us.battle.net/api/d3/data/item/promise-of-glory",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_002_x1_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Promise of Glory"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/guardians-bands",
+	"url_name": "guardians-bands",
+	"api_url": "https://us.battle.net/api/d3/data/item/guardians-bands",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_010_1xx_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "set",
+	"name": "Guardian's Deflector"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/lacuni-prowlers",
+	"url_name": "lacuni-prowlers",
+	"api_url": "https://us.battle.net/api/d3/data/item/lacuni-prowlers",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_005_x1_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Lacuni Prowlers"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/strongarm-bracers",
+	"url_name": "strongarm-bracers",
+	"api_url": "https://us.battle.net/api/d3/data/item/strongarm-bracers",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_007_x1_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Strongarm Bracers"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/wondrous-deflectors",
+	"url_name": "wondrous-deflectors",
+	"api_url": "https://us.battle.net/api/d3/data/item/wondrous-deflectors",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_001_1xx_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Wondrous Deflectors"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demons-manacles",
+	"url_name": "demons-manacles",
+	"api_url": "https://us.battle.net/api/d3/data/item/demons-manacles",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_011_1xx_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "set",
+	"name": "Demon's Revenge"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/coils-of-the-first-spider",
+	"url_name": "coils-of-the-first-spider",
+	"api_url": "https://us.battle.net/api/d3/data/item/coils-of-the-first-spider",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_bracer_107_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Coils of the First Spider"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/drakons-lesson",
+	"url_name": "drakons-lesson",
+	"api_url": "https://us.battle.net/api/d3/data/item/drakons-lesson",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_bracer_110_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Drakon's Lesson"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/kethryes-splint",
+	"url_name": "kethryes-splint",
+	"api_url": "https://us.battle.net/api/d3/data/item/kethryes-splint",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_001_x1_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Kethryes' Splint"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/lakumbas-ornament",
+	"url_name": "lakumbas-ornament",
+	"api_url": "https://us.battle.net/api/d3/data/item/lakumbas-ornament",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_bracer_102_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Lakumba’s Ornament"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/ranslors-folly",
+	"url_name": "ranslors-folly",
+	"api_url": "https://us.battle.net/api/d3/data/item/ranslors-folly",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_108_x1_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Ranslor's Folly"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/reapers-wraps",
+	"url_name": "reapers-wraps",
+	"api_url": "https://us.battle.net/api/d3/data/item/reapers-wraps",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_103_x1_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Reaper's Wraps"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/skulars-salvation",
+	"url_name": "skulars-salvation",
+	"api_url": "https://us.battle.net/api/d3/data/item/skulars-salvation",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_bracer_101_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Skular's Salvation"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/spirit-guards",
+	"url_name": "spirit-guards",
+	"api_url": "https://us.battle.net/api/d3/data/item/spirit-guards",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_bracer_109_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Spirit Guards"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/tragoul-coils",
+	"url_name": "tragoul-coils",
+	"api_url": "https://us.battle.net/api/d3/data/item/tragoul-coils",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_104_x1_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "legendary",
+	"name": "Trag'Oul Coils"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/aughilds-search",
+	"url_name": "aughilds-search",
+	"api_url": "https://us.battle.net/api/d3/data/item/aughilds-search",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_009_x1_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "set",
+	"name": "Aughild's Search"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demons-animus",
+	"url_name": "demons-animus",
+	"api_url": "https://us.battle.net/api/d3/data/item/demons-animus",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_011_x1_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "set",
+	"name": "Demon's Animus"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/guardians-aversion",
+	"url_name": "guardians-aversion",
+	"api_url": "https://us.battle.net/api/d3/data/item/guardians-aversion",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_010_x1_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "set",
+	"name": "Guardian's Aversion"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/krelms-buff-bracers",
+	"url_name": "krelms-buff-bracers",
+	"api_url": "https://us.battle.net/api/d3/data/item/krelms-buff-bracers",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_set_02_x1_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "set",
+	"name": "Krelm's Buff Bracers"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/shackles-of-the-invoker",
+	"url_name": "shackles-of-the-invoker",
+	"api_url": "https://us.battle.net/api/d3/data/item/shackles-of-the-invoker",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bracer_set_12_x1_demonhunter_male.png",
+	"type": "bracers",
+	"quality": "set",
+	"name": "Shackles of the Invoker"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/gloves-of-worship",
+	"url_name": "gloves-of-worship",
+	"api_url": "https://us.battle.net/api/d3/data/item/gloves-of-worship",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_103_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "legendary",
+	"name": "Gloves of Worship"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/cains-warmers",
+	"url_name": "cains-warmers",
+	"api_url": "https://us.battle.net/api/d3/data/item/cains-warmers",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_015_1xx_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Cain's Scribe"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/stone-gauntlets",
+	"url_name": "stone-gauntlets",
+	"api_url": "https://us.battle.net/api/d3/data/item/stone-gauntlets",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_007_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "legendary",
+	"name": "Stone Gauntlets"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/magefist",
+	"url_name": "magefist",
+	"api_url": "https://us.battle.net/api/d3/data/item/magefist",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_014_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "legendary",
+	"name": "Magefist"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/st-archews-gage",
+	"url_name": "st-archews-gage",
+	"api_url": "https://us.battle.net/api/d3/data/item/st-archews-gage",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_101_p2_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "legendary",
+	"name": "St. Archew's Gage"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/pendergrasps",
+	"url_name": "pendergrasps",
+	"api_url": "https://us.battle.net/api/d3/data/item/pendergrasps",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_001_1xx_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "legendary",
+	"name": "Pendergrasps"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/gladiator-gauntlets",
+	"url_name": "gladiator-gauntlets",
+	"api_url": "https://us.battle.net/api/d3/data/item/gladiator-gauntlets",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_011_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "legendary",
+	"name": "Gladiator Gauntlets"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/ashearas-clasp",
+	"url_name": "ashearas-clasp",
+	"api_url": "https://us.battle.net/api/d3/data/item/ashearas-clasp",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_009_1xx_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Asheara's Iron Fist"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/frostburn",
+	"url_name": "frostburn",
+	"api_url": "https://us.battle.net/api/d3/data/item/frostburn",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_002_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "legendary",
+	"name": "Frostburn"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/tasker-and-theo",
+	"url_name": "tasker-and-theo",
+	"api_url": "https://us.battle.net/api/d3/data/item/tasker-and-theo",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_003_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "legendary",
+	"name": "Tasker and Theo"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/immortal-kings-irons",
+	"url_name": "immortal-kings-irons",
+	"api_url": "https://us.battle.net/api/d3/data/item/immortal-kings-irons",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_008_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Immortal King's Irons"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/innas-hold",
+	"url_name": "innas-hold",
+	"api_url": "https://us.battle.net/api/d3/data/item/innas-hold",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_gloves_04_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Inna's Hold"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/natalyas-touch",
+	"url_name": "natalyas-touch",
+	"api_url": "https://us.battle.net/api/d3/data/item/natalyas-touch",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_gloves_01_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Natalya's Touch"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/tal-rashas-grasp",
+	"url_name": "tal-rashas-grasp",
+	"api_url": "https://us.battle.net/api/d3/data/item/tal-rashas-grasp",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_gloves_02_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Tal Rasha's Grasp"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/zunimassas-finger-wraps",
+	"url_name": "zunimassas-finger-wraps",
+	"api_url": "https://us.battle.net/api/d3/data/item/zunimassas-finger-wraps",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_gloves_03_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Zunimassa's Finger Wraps"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/sages-grasp",
+	"url_name": "sages-grasp",
+	"api_url": "https://us.battle.net/api/d3/data/item/sages-grasp",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_017_1xx_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Sage's Gesture"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/penders-purchase",
+	"url_name": "penders-purchase",
+	"api_url": "https://us.battle.net/api/d3/data/item/penders-purchase",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_001_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "legendary",
+	"name": "Penders Purchase"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/arachyrs-claws",
+	"url_name": "arachyrs-claws",
+	"api_url": "https://us.battle.net/api/d3/data/item/arachyrs-claws",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_02_p3_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Arachyr’s Claws"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/ashearas-ward",
+	"url_name": "ashearas-ward",
+	"api_url": "https://us.battle.net/api/d3/data/item/ashearas-ward",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_009_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Asheara's Ward"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/cains-scriviner",
+	"url_name": "cains-scriviner",
+	"api_url": "https://us.battle.net/api/d3/data/item/cains-scriviner",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_015_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Cain's Scrivener"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/fiendish-grips",
+	"url_name": "fiendish-grips",
+	"api_url": "https://us.battle.net/api/d3/data/item/fiendish-grips",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_03_p2_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Fiendish Grips"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/fierce-gauntlets",
+	"url_name": "fierce-gauntlets",
+	"api_url": "https://us.battle.net/api/d3/data/item/fierce-gauntlets",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_02_p2_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Fierce Gauntlets"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/firebirds-talons",
+	"url_name": "firebirds-talons",
+	"api_url": "https://us.battle.net/api/d3/data/item/firebirds-talons",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_06_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Firebird's Talons"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/fists-of-thunder",
+	"url_name": "fists-of-thunder",
+	"api_url": "https://us.battle.net/api/d3/data/item/fists-of-thunder",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_08_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Fists of Thunder"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/gauntlet-of-the-wastes",
+	"url_name": "gauntlet-of-the-wastes",
+	"api_url": "https://us.battle.net/api/d3/data/item/gauntlet-of-the-wastes",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_01_p2_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Gauntlet of the Wastes"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/gauntlets-of-akkhan",
+	"url_name": "gauntlets-of-akkhan",
+	"api_url": "https://us.battle.net/api/d3/data/item/gauntlets-of-akkhan",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_10_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Gauntlets of Akkhan"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/helltooth-gauntlets",
+	"url_name": "helltooth-gauntlets",
+	"api_url": "https://us.battle.net/api/d3/data/item/helltooth-gauntlets",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_16_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Helltooth Gauntlets"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/jade-harvesters-mercy",
+	"url_name": "jade-harvesters-mercy",
+	"api_url": "https://us.battle.net/api/d3/data/item/jade-harvesters-mercy",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_09_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Jade Harvester's Mercy"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/marauders-gloves",
+	"url_name": "marauders-gloves",
+	"api_url": "https://us.battle.net/api/d3/data/item/marauders-gloves",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_07_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Marauder's Gloves"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/pride-of-the-invoker",
+	"url_name": "pride-of-the-invoker",
+	"api_url": "https://us.battle.net/api/d3/data/item/pride-of-the-invoker",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_12_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Pride of the Invoker"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/pull-of-the-earth",
+	"url_name": "pull-of-the-earth",
+	"api_url": "https://us.battle.net/api/d3/data/item/pull-of-the-earth",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_15_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Pull of the Earth"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/raekors-wraps",
+	"url_name": "raekors-wraps",
+	"api_url": "https://us.battle.net/api/d3/data/item/raekors-wraps",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_05_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Raekor's Wraps"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/rolands-grasp",
+	"url_name": "rolands-grasp",
+	"api_url": "https://us.battle.net/api/d3/data/item/rolands-grasp",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_01_p1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Roland's Grasp"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/sages-purchase",
+	"url_name": "sages-purchase",
+	"api_url": "https://us.battle.net/api/d3/data/item/sages-purchase",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_017_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Sage's Purchase"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/sunwukos-paws",
+	"url_name": "sunwukos-paws",
+	"api_url": "https://us.battle.net/api/d3/data/item/sunwukos-paws",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_11_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Sunwuko's Paws"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-shadows-grasp",
+	"url_name": "the-shadows-grasp",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-shadows-grasp",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_14_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "The Shadow's Grasp"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/ulianas-fury",
+	"url_name": "ulianas-fury",
+	"api_url": "https://us.battle.net/api/d3/data/item/ulianas-fury",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_01_p3_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Uliana's Fury"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/vyrs-grasping-gauntlets",
+	"url_name": "vyrs-grasping-gauntlets",
+	"api_url": "https://us.battle.net/api/d3/data/item/vyrs-grasping-gauntlets",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_13_x1_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Vyr's Grasping Gauntlets"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/will-of-the-light",
+	"url_name": "will-of-the-light",
+	"api_url": "https://us.battle.net/api/d3/data/item/will-of-the-light",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_gloves_set_03_p3_demonhunter_male.png",
+	"type": "gloves",
+	"quality": "set",
+	"name": "Will of the Light"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/goldwrap",
+	"url_name": "goldwrap",
+	"api_url": "https://us.battle.net/api/d3/data/item/goldwrap",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_010_x1_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Goldwrap"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/vigilante-belt",
+	"url_name": "vigilante-belt",
+	"api_url": "https://us.battle.net/api/d3/data/item/vigilante-belt",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_002_x1_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Vigilante Belt"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/insatiable-belt",
+	"url_name": "insatiable-belt",
+	"api_url": "https://us.battle.net/api/d3/data/item/insatiable-belt",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_103_x1_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Insatiable Belt"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/binding-of-the-lost",
+	"url_name": "binding-of-the-lost",
+	"api_url": "https://us.battle.net/api/d3/data/item/binding-of-the-lost",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_belt_03_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Binding of the Lost"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-shame-of-delsere",
+	"url_name": "the-shame-of-delsere",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-shame-of-delsere",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_belt_02_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "The Shame of Delsere"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/kyoshiros-soul",
+	"url_name": "kyoshiros-soul",
+	"api_url": "https://us.battle.net/api/d3/data/item/kyoshiros-soul",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_belt_05_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Kyoshiro's Soul"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/sacred-harness",
+	"url_name": "sacred-harness",
+	"api_url": "https://us.battle.net/api/d3/data/item/sacred-harness",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_belt_01_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Sacred Harness"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/quick-draw-belt",
+	"url_name": "quick-draw-belt",
+	"api_url": "https://us.battle.net/api/d3/data/item/quick-draw-belt",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_004_1xx_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Quick Draw Belt"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/saffron-wrap",
+	"url_name": "saffron-wrap",
+	"api_url": "https://us.battle.net/api/d3/data/item/saffron-wrap",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_001_x1_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Saffron Wrap"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/string-of-ears",
+	"url_name": "string-of-ears",
+	"api_url": "https://us.battle.net/api/d3/data/item/string-of-ears",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_belt_03_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "String of Ears"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/fazulas-improbable-chain",
+	"url_name": "fazulas-improbable-chain",
+	"api_url": "https://us.battle.net/api/d3/data/item/fazulas-improbable-chain",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_belt_07_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Fazula’s Improbable Chain"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/hergbrashs-binding",
+	"url_name": "hergbrashs-binding",
+	"api_url": "https://us.battle.net/api/d3/data/item/hergbrashs-binding",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_belt_06_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Hergbrash’s Binding"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/captain-crimsons-brace",
+	"url_name": "captain-crimsons-brace",
+	"api_url": "https://us.battle.net/api/d3/data/item/captain-crimsons-brace",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_012_1xx_demonhunter_male.png",
+	"type": "belt",
+	"quality": "set",
+	"name": "Captain Crimson's Satin Sash"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/belt-of-transcendence",
+	"url_name": "belt-of-transcendence",
+	"api_url": "https://us.battle.net/api/d3/data/item/belt-of-transcendence",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_belt_02_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Belt of Transcendence"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/blessed-of-haull",
+	"url_name": "blessed-of-haull",
+	"api_url": "https://us.battle.net/api/d3/data/item/blessed-of-haull",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_belt_05_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Blessed of Haull"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/chain-of-shadows",
+	"url_name": "chain-of-shadows",
+	"api_url": "https://us.battle.net/api/d3/data/item/chain-of-shadows",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_belt_01_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Chain of Shadows"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/cord-of-the-sherma",
+	"url_name": "cord-of-the-sherma",
+	"api_url": "https://us.battle.net/api/d3/data/item/cord-of-the-sherma",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_104_p2_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Cord of the Sherma"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/crashing-rain",
+	"url_name": "crashing-rain",
+	"api_url": "https://us.battle.net/api/d3/data/item/crashing-rain",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_belt_01_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Crashing Rain"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/harrington-waistguard",
+	"url_name": "harrington-waistguard",
+	"api_url": "https://us.battle.net/api/d3/data/item/harrington-waistguard",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_105_x1_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Harrington Waistguard"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/haunting-girdle",
+	"url_name": "haunting-girdle",
+	"api_url": "https://us.battle.net/api/d3/data/item/haunting-girdle",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_belt_03_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Haunting Girdle"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/hwoj-wrap",
+	"url_name": "hwoj-wrap",
+	"api_url": "https://us.battle.net/api/d3/data/item/hwoj-wrap",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_107_x1_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Hwoj Wrap"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/omnislash",
+	"url_name": "omnislash",
+	"api_url": "https://us.battle.net/api/d3/data/item/omnislash",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_belt_04_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Omnislash"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/omryns-chain",
+	"url_name": "omryns-chain",
+	"api_url": "https://us.battle.net/api/d3/data/item/omryns-chain",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_belt_06_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Omryn's Chain"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/razor-strop",
+	"url_name": "razor-strop",
+	"api_url": "https://us.battle.net/api/d3/data/item/razor-strop",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_101_x1_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Razor Strop"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/sash-of-knives",
+	"url_name": "sash-of-knives",
+	"api_url": "https://us.battle.net/api/d3/data/item/sash-of-knives",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_102_p2_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Sash of Knives"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/sebors-nightmare",
+	"url_name": "sebors-nightmare",
+	"api_url": "https://us.battle.net/api/d3/data/item/sebors-nightmare",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_108_p2_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Sebor's Nightmare"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/angel-hair-braid",
+	"url_name": "angel-hair-braid",
+	"api_url": "https://us.battle.net/api/d3/data/item/angel-hair-braid",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_003_p1_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Angel Hair Braid"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/thundergods-vigor",
+	"url_name": "thundergods-vigor",
+	"api_url": "https://us.battle.net/api/d3/data/item/thundergods-vigor",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_barbbelt_003_x1_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Thundergod's Vigor"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/guardians-scabbard",
+	"url_name": "guardians-scabbard",
+	"api_url": "https://us.battle.net/api/d3/data/item/guardians-scabbard",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_013_1xx_demonhunter_male.png",
+	"type": "belt",
+	"quality": "set",
+	"name": "Guardian's Sheath"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/belt-of-the-trove",
+	"url_name": "belt-of-the-trove",
+	"api_url": "https://us.battle.net/api/d3/data/item/belt-of-the-trove",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_belt_008_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Belt of the Trove"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/hellcat-waistguard",
+	"url_name": "hellcat-waistguard",
+	"api_url": "https://us.battle.net/api/d3/data/item/hellcat-waistguard",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_005_x1_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Hellcat Waistguard"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-witching-hour",
+	"url_name": "the-witching-hour",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-witching-hour",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_009_x1_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "The Witching Hour"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/blackthornes-notched-belt",
+	"url_name": "blackthornes-notched-belt",
+	"api_url": "https://us.battle.net/api/d3/data/item/blackthornes-notched-belt",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_015_x1_demonhunter_male.png",
+	"type": "belt",
+	"quality": "set",
+	"name": "Blackthorne's Notched Belt"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/innas-favor",
+	"url_name": "innas-favor",
+	"api_url": "https://us.battle.net/api/d3/data/item/innas-favor",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_007_x1_demonhunter_male.png",
+	"type": "belt",
+	"quality": "set",
+	"name": "Inna's Favor"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/tal-rashas-brace",
+	"url_name": "tal-rashas-brace",
+	"api_url": "https://us.battle.net/api/d3/data/item/tal-rashas-brace",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_006_x1_demonhunter_male.png",
+	"type": "belt",
+	"quality": "set",
+	"name": "Tal Rasha's Brace"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demons-binding",
+	"url_name": "demons-binding",
+	"api_url": "https://us.battle.net/api/d3/data/item/demons-binding",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_014_1xx_demonhunter_male.png",
+	"type": "belt",
+	"quality": "set",
+	"name": "Demon's Lock"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/jangs-envelopment",
+	"url_name": "jangs-envelopment",
+	"api_url": "https://us.battle.net/api/d3/data/item/jangs-envelopment",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_106_x1_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Jang's Envelopment"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/fleeting-strap",
+	"url_name": "fleeting-strap",
+	"api_url": "https://us.battle.net/api/d3/data/item/fleeting-strap",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_004_x1_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Fleeting Strap"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/hunters-wrath",
+	"url_name": "hunters-wrath",
+	"api_url": "https://us.battle.net/api/d3/data/item/hunters-wrath",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_belt_005_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Hunter's Wrath"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/zoeys-secret",
+	"url_name": "zoeys-secret",
+	"api_url": "https://us.battle.net/api/d3/data/item/zoeys-secret",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_belt_04_demonhunter_male.png",
+	"type": "belt",
+	"quality": "legendary",
+	"name": "Zoey's Secret"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/captain-crimsons-silk-girdle",
+	"url_name": "captain-crimsons-silk-girdle",
+	"api_url": "https://us.battle.net/api/d3/data/item/captain-crimsons-silk-girdle",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_012_x1_demonhunter_male.png",
+	"type": "belt",
+	"quality": "set",
+	"name": "Captain Crimson's Silk Girdle"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demons-restraint",
+	"url_name": "demons-restraint",
+	"api_url": "https://us.battle.net/api/d3/data/item/demons-restraint",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_014_x1_demonhunter_male.png",
+	"type": "belt",
+	"quality": "set",
+	"name": "Demon's Restraint"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/guardians-case",
+	"url_name": "guardians-case",
+	"api_url": "https://us.battle.net/api/d3/data/item/guardians-case",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_013_x1_demonhunter_male.png",
+	"type": "belt",
+	"quality": "set",
+	"name": "Guardian's Case"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/krelms-buff-belt",
+	"url_name": "krelms-buff-belt",
+	"api_url": "https://us.battle.net/api/d3/data/item/krelms-buff-belt",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_belt_set_02_x1_demonhunter_male.png",
+	"type": "belt",
+	"quality": "set",
+	"name": "Krelm's Buff Belt"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/girdle-of-giants",
+	"url_name": "girdle-of-giants",
+	"api_url": "https://us.battle.net/api/d3/data/item/girdle-of-giants",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_barbbelt_004_x1_demonhunter_male.png",
+	"type": "mighty-belt",
+	"quality": "legendary",
+	"name": "Girdle of Giants"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-undisputed-champion",
+	"url_name": "the-undisputed-champion",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-undisputed-champion",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_barbbelt_006_demonhunter_male.png",
+	"type": "mighty-belt",
+	"quality": "legendary",
+	"name": "The Undisputed Champion"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/kotuurs-brace",
+	"url_name": "kotuurs-brace",
+	"api_url": "https://us.battle.net/api/d3/data/item/kotuurs-brace",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_barbbelt_007_x1_demonhunter_male.png",
+	"type": "mighty-belt",
+	"quality": "legendary",
+	"name": "Kotuur's Brace"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/pride-of-cassius",
+	"url_name": "pride-of-cassius",
+	"api_url": "https://us.battle.net/api/d3/data/item/pride-of-cassius",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_barbbelt_002_x1_demonhunter_male.png",
+	"type": "mighty-belt",
+	"quality": "legendary",
+	"name": "Pride of Cassius"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/chilaniks-chain",
+	"url_name": "chilaniks-chain",
+	"api_url": "https://us.battle.net/api/d3/data/item/chilaniks-chain",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_barbbelt_101_x1_demonhunter_male.png",
+	"type": "mighty-belt",
+	"quality": "legendary",
+	"name": "Chilanik's Chain"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/lamentation",
+	"url_name": "lamentation",
+	"api_url": "https://us.battle.net/api/d3/data/item/lamentation",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_barbbelt_005_p1_demonhunter_male.png",
+	"type": "mighty-belt",
+	"quality": "legendary",
+	"name": "Lamentation"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/immortal-kings-tribal-binding",
+	"url_name": "immortal-kings-tribal-binding",
+	"api_url": "https://us.battle.net/api/d3/data/item/immortal-kings-tribal-binding",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_barbbelt_009_x1_demonhunter_male.png",
+	"type": "mighty-belt",
+	"quality": "set",
+	"name": "Immortal King's Tribal Binding"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/dread-iron",
+	"url_name": "dread-iron",
+	"api_url": "https://us.battle.net/api/d3/data/item/dread-iron",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_barbbelt_001_demonhunter_male.png",
+	"type": "mighty-belt",
+	"quality": "legendary",
+	"name": "Dread Iron"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/pox-faulds",
+	"url_name": "pox-faulds",
+	"api_url": "https://us.battle.net/api/d3/data/item/pox-faulds",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_007_p2_demonhunter_male.png",
+	"type": "pants",
+	"quality": "legendary",
+	"name": "Pox Faulds"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/deaths-bargain",
+	"url_name": "deaths-bargain",
+	"api_url": "https://us.battle.net/api/d3/data/item/deaths-bargain",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_102_x1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "legendary",
+	"name": "Death's Bargain"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/cains-raiment",
+	"url_name": "cains-raiment",
+	"api_url": "https://us.battle.net/api/d3/data/item/cains-raiment",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_010_1xx_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Cain's Robes"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/hammer-jammers",
+	"url_name": "hammer-jammers",
+	"api_url": "https://us.battle.net/api/d3/data/item/hammer-jammers",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_pants_002_demonhunter_male.png",
+	"type": "pants",
+	"quality": "legendary",
+	"name": "Hammer Jammers"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/captain-crimsons-codpiece",
+	"url_name": "captain-crimsons-codpiece",
+	"api_url": "https://us.battle.net/api/d3/data/item/captain-crimsons-codpiece",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_012_1xx_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Captain Crimson's Bowsprit"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/hexing-pants-of-mr-yan",
+	"url_name": "hexing-pants-of-mr-yan",
+	"api_url": "https://us.battle.net/api/d3/data/item/hexing-pants-of-mr-yan",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_101_x1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "legendary",
+	"name": "Hexing Pants of Mr. Yan"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/swamp-land-waders",
+	"url_name": "swamp-land-waders",
+	"api_url": "https://us.battle.net/api/d3/data/item/swamp-land-waders",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_001_x1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "legendary",
+	"name": "Swamp Land Waders"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/ashearas-cradle",
+	"url_name": "ashearas-cradle",
+	"api_url": "https://us.battle.net/api/d3/data/item/ashearas-cradle",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_009_1xx_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Asheara's Gait"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/depth-diggers",
+	"url_name": "depth-diggers",
+	"api_url": "https://us.battle.net/api/d3/data/item/depth-diggers",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_006_p1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "legendary",
+	"name": "Depth Diggers"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/blackthornes-jousting-mail",
+	"url_name": "blackthornes-jousting-mail",
+	"api_url": "https://us.battle.net/api/d3/data/item/blackthornes-jousting-mail",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_013_x1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Blackthorne's Jousting Mail"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/immortal-kings-stature",
+	"url_name": "immortal-kings-stature",
+	"api_url": "https://us.battle.net/api/d3/data/item/immortal-kings-stature",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_pants_02_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Immortal King's Stature"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/innas-temperance",
+	"url_name": "innas-temperance",
+	"api_url": "https://us.battle.net/api/d3/data/item/innas-temperance",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_008_x1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Inna's Temperance"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/natalyas-leggings",
+	"url_name": "natalyas-leggings",
+	"api_url": "https://us.battle.net/api/d3/data/item/natalyas-leggings",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_pants_01_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Natalya's Leggings"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/tal-rashas-stride",
+	"url_name": "tal-rashas-stride",
+	"api_url": "https://us.battle.net/api/d3/data/item/tal-rashas-stride",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_pants_03_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Tal Rasha's Stride"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/zunimassas-cloth",
+	"url_name": "zunimassas-cloth",
+	"api_url": "https://us.battle.net/api/d3/data/item/zunimassas-cloth",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_pants_04_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Zunimassa's Cloth"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/gehennas",
+	"url_name": "gehennas",
+	"api_url": "https://us.battle.net/api/d3/data/item/gehennas",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_005_1xx_demonhunter_male.png",
+	"type": "pants",
+	"quality": "legendary",
+	"name": "Gehennas"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demons-flesh",
+	"url_name": "demons-flesh",
+	"api_url": "https://us.battle.net/api/d3/data/item/demons-flesh",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_014_1xx_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Demon's Scale"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/skelons-deceit",
+	"url_name": "skelons-deceit",
+	"api_url": "https://us.battle.net/api/d3/data/item/skelons-deceit",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_005_x1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "legendary",
+	"name": "Skelon's Deceit"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/arachyrs-legs",
+	"url_name": "arachyrs-legs",
+	"api_url": "https://us.battle.net/api/d3/data/item/arachyrs-legs",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_02_p3_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Arachyr’s Legs"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/ashearas-pace",
+	"url_name": "ashearas-pace",
+	"api_url": "https://us.battle.net/api/d3/data/item/ashearas-pace",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_009_x1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Asheara's Pace"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/cains-habit",
+	"url_name": "cains-habit",
+	"api_url": "https://us.battle.net/api/d3/data/item/cains-habit",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_010_x1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Cain's Habit"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/captain-crimsons-thrust",
+	"url_name": "captain-crimsons-thrust",
+	"api_url": "https://us.battle.net/api/d3/data/item/captain-crimsons-thrust",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_012_x1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Captain Crimson's Thrust"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/cuisses-of-akkhan",
+	"url_name": "cuisses-of-akkhan",
+	"api_url": "https://us.battle.net/api/d3/data/item/cuisses-of-akkhan",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_10_x1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Cuisses of Akkhan"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demons-plate",
+	"url_name": "demons-plate",
+	"api_url": "https://us.battle.net/api/d3/data/item/demons-plate",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_014_x1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Demon's Plate"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/firebirds-down",
+	"url_name": "firebirds-down",
+	"api_url": "https://us.battle.net/api/d3/data/item/firebirds-down",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_06_x1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Firebird's Down"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/helltooth-leg-guards",
+	"url_name": "helltooth-leg-guards",
+	"api_url": "https://us.battle.net/api/d3/data/item/helltooth-leg-guards",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_16_x1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Helltooth Leg Guards"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/jade-harvesters-courage",
+	"url_name": "jade-harvesters-courage",
+	"api_url": "https://us.battle.net/api/d3/data/item/jade-harvesters-courage",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_09_x1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Jade Harvester's Courage"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/leg-guards-of-mystery",
+	"url_name": "leg-guards-of-mystery",
+	"api_url": "https://us.battle.net/api/d3/data/item/leg-guards-of-mystery",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_02_p2_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Leg Guards of Mystery"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/marauders-encasement",
+	"url_name": "marauders-encasement",
+	"api_url": "https://us.battle.net/api/d3/data/item/marauders-encasement",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_07_x1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Marauder's Encasement"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/raekors-breeches",
+	"url_name": "raekors-breeches",
+	"api_url": "https://us.battle.net/api/d3/data/item/raekors-breeches",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_05_x1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Raekor's Breeches"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/renewal-of-the-invoker",
+	"url_name": "renewal-of-the-invoker",
+	"api_url": "https://us.battle.net/api/d3/data/item/renewal-of-the-invoker",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_12_x1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Renewal of the Invoker"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/rolands-determination",
+	"url_name": "rolands-determination",
+	"api_url": "https://us.battle.net/api/d3/data/item/rolands-determination",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_01_p1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Roland's Determination"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/scales-of-the-dancing-serpent",
+	"url_name": "scales-of-the-dancing-serpent",
+	"api_url": "https://us.battle.net/api/d3/data/item/scales-of-the-dancing-serpent",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_08_x1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Scales of the Dancing Serpent"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/sunwukos-leggings",
+	"url_name": "sunwukos-leggings",
+	"api_url": "https://us.battle.net/api/d3/data/item/sunwukos-leggings",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_11_x1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Sunwuko's Leggings"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/tasset-of-the-wastes",
+	"url_name": "tasset-of-the-wastes",
+	"api_url": "https://us.battle.net/api/d3/data/item/tasset-of-the-wastes",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_01_p2_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Tasset of the Wastes"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-shadows-coil",
+	"url_name": "the-shadows-coil",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-shadows-coil",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_14_x1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "The Shadow's Coil"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/towers-of-the-light",
+	"url_name": "towers-of-the-light",
+	"api_url": "https://us.battle.net/api/d3/data/item/towers-of-the-light",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_03_p3_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Towers of the Light"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/ulianas-burden",
+	"url_name": "ulianas-burden",
+	"api_url": "https://us.battle.net/api/d3/data/item/ulianas-burden",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_01_p3_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Uliana's Burden"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/unholy-plates",
+	"url_name": "unholy-plates",
+	"api_url": "https://us.battle.net/api/d3/data/item/unholy-plates",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_03_p2_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Unholy Plates"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/vyrs-fantastic-finery",
+	"url_name": "vyrs-fantastic-finery",
+	"api_url": "https://us.battle.net/api/d3/data/item/vyrs-fantastic-finery",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_13_x1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Vyr's Fantastic Finery"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/weight-of-the-earth",
+	"url_name": "weight-of-the-earth",
+	"api_url": "https://us.battle.net/api/d3/data/item/weight-of-the-earth",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_pants_set_15_x1_demonhunter_male.png",
+	"type": "pants",
+	"quality": "set",
+	"name": "Weight of the Earth"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/lut-socks",
+	"url_name": "lut-socks",
+	"api_url": "https://us.battle.net/api/d3/data/item/lut-socks",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_009_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "legendary",
+	"name": "Lut Socks"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/rivera-dancers",
+	"url_name": "rivera-dancers",
+	"api_url": "https://us.battle.net/api/d3/data/item/rivera-dancers",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_boots_001_demonhunter_male.png",
+	"type": "boots",
+	"quality": "legendary",
+	"name": "Rivera Dancers"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-crudest-boots",
+	"url_name": "the-crudest-boots",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-crudest-boots",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p1_unique_boots_010_demonhunter_male.png",
+	"type": "boots",
+	"quality": "legendary",
+	"name": "The Crudest Boots"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/boots-of-disregard",
+	"url_name": "boots-of-disregard",
+	"api_url": "https://us.battle.net/api/d3/data/item/boots-of-disregard",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_102_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "legendary",
+	"name": "Boots of Disregard"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/illusory-boots",
+	"url_name": "illusory-boots",
+	"api_url": "https://us.battle.net/api/d3/data/item/illusory-boots",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_103_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "legendary",
+	"name": "Illusory Boots"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/cains-slippers",
+	"url_name": "cains-slippers",
+	"api_url": "https://us.battle.net/api/d3/data/item/cains-slippers",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_015_1xx_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Cain's Sandals"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/captain-crimsons-deck-boots",
+	"url_name": "captain-crimsons-deck-boots",
+	"api_url": "https://us.battle.net/api/d3/data/item/captain-crimsons-deck-boots",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_017_1xx_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Captain Crimson's Whalers"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/irontoe-mudsputters",
+	"url_name": "irontoe-mudsputters",
+	"api_url": "https://us.battle.net/api/d3/data/item/irontoe-mudsputters",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_104_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "legendary",
+	"name": "Irontoe Mudsputters"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/fire-walkers",
+	"url_name": "fire-walkers",
+	"api_url": "https://us.battle.net/api/d3/data/item/fire-walkers",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_007_p2_demonhunter_male.png",
+	"type": "boots",
+	"quality": "legendary",
+	"name": "Fire Walkers"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/lost-boys",
+	"url_name": "lost-boys",
+	"api_url": "https://us.battle.net/api/d3/data/item/lost-boys",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_005_1xx_demonhunter_male.png",
+	"type": "boots",
+	"quality": "legendary",
+	"name": "Lost Boys"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/ashearas-lock",
+	"url_name": "ashearas-lock",
+	"api_url": "https://us.battle.net/api/d3/data/item/ashearas-lock",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_014_1xx_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Asheara's Tracks"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/ice-climbers",
+	"url_name": "ice-climbers",
+	"api_url": "https://us.battle.net/api/d3/data/item/ice-climbers",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_008_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "legendary",
+	"name": "Ice Climbers"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/nilfurs-boast",
+	"url_name": "nilfurs-boast",
+	"api_url": "https://us.battle.net/api/d3/data/item/nilfurs-boast",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_boots_01_demonhunter_male.png",
+	"type": "boots",
+	"quality": "legendary",
+	"name": "Nilfur's Boast"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/blackthornes-spurs",
+	"url_name": "blackthornes-spurs",
+	"api_url": "https://us.battle.net/api/d3/data/item/blackthornes-spurs",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_019_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Blackthorne's Spurs"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/immortal-kings-stride",
+	"url_name": "immortal-kings-stride",
+	"api_url": "https://us.battle.net/api/d3/data/item/immortal-kings-stride",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_012_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Immortal King's Stride"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/innas-sandals",
+	"url_name": "innas-sandals",
+	"api_url": "https://us.battle.net/api/d3/data/item/innas-sandals",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_boots_02_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Inna's Sandals"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/natalyas-bloody-footprints",
+	"url_name": "natalyas-bloody-footprints",
+	"api_url": "https://us.battle.net/api/d3/data/item/natalyas-bloody-footprints",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_011_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Natalya's Bloody Footprints"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/zunimassas-trail",
+	"url_name": "zunimassas-trail",
+	"api_url": "https://us.battle.net/api/d3/data/item/zunimassas-trail",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_013_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Zunimassa's Trail"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/sages-seekers",
+	"url_name": "sages-seekers",
+	"api_url": "https://us.battle.net/api/d3/data/item/sages-seekers",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_018_1xx_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Sage's Journey"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/board-walkers",
+	"url_name": "board-walkers",
+	"api_url": "https://us.battle.net/api/d3/data/item/board-walkers",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_005_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "legendary",
+	"name": "Board Walkers"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/arachyrs-stride",
+	"url_name": "arachyrs-stride",
+	"api_url": "https://us.battle.net/api/d3/data/item/arachyrs-stride",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_02_p3_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Arachyr’s Stride"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/ashearas-finders",
+	"url_name": "ashearas-finders",
+	"api_url": "https://us.battle.net/api/d3/data/item/ashearas-finders",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_014_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Asheara's Finders"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/cains-travelers",
+	"url_name": "cains-travelers",
+	"api_url": "https://us.battle.net/api/d3/data/item/cains-travelers",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_015_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Cain's Travelers"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/captain-crimsons-waders",
+	"url_name": "captain-crimsons-waders",
+	"api_url": "https://us.battle.net/api/d3/data/item/captain-crimsons-waders",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_017_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Captain Crimson's Waders"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/eightdemon-boots",
+	"url_name": "eightdemon-boots",
+	"api_url": "https://us.battle.net/api/d3/data/item/eightdemon-boots",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_08_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Eight-Demon Boots"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/firebirds-tarsi",
+	"url_name": "firebirds-tarsi",
+	"api_url": "https://us.battle.net/api/d3/data/item/firebirds-tarsi",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_06_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Firebird's Tarsi"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/foundation-of-the-earth",
+	"url_name": "foundation-of-the-earth",
+	"api_url": "https://us.battle.net/api/d3/data/item/foundation-of-the-earth",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_15_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Foundation of the Earth"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/foundation-of-the-light",
+	"url_name": "foundation-of-the-light",
+	"api_url": "https://us.battle.net/api/d3/data/item/foundation-of-the-light",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_03_p3_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Foundation of the Light"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/hell-walkers",
+	"url_name": "hell-walkers",
+	"api_url": "https://us.battle.net/api/d3/data/item/hell-walkers",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_03_p2_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Hell Walkers"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/helltooth-greaves",
+	"url_name": "helltooth-greaves",
+	"api_url": "https://us.battle.net/api/d3/data/item/helltooth-greaves",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_16_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Helltooth Greaves"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/jade-harvesters-swiftness",
+	"url_name": "jade-harvesters-swiftness",
+	"api_url": "https://us.battle.net/api/d3/data/item/jade-harvesters-swiftness",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_09_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Jade Harvester's Swiftness"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/marauders-treads",
+	"url_name": "marauders-treads",
+	"api_url": "https://us.battle.net/api/d3/data/item/marauders-treads",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_07_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Marauder's Treads"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/raekors-striders",
+	"url_name": "raekors-striders",
+	"api_url": "https://us.battle.net/api/d3/data/item/raekors-striders",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_05_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Raekor's Striders"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/rolands-stride",
+	"url_name": "rolands-stride",
+	"api_url": "https://us.battle.net/api/d3/data/item/rolands-stride",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_01_p1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Roland's Stride"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/sabaton-of-the-wastes",
+	"url_name": "sabaton-of-the-wastes",
+	"api_url": "https://us.battle.net/api/d3/data/item/sabaton-of-the-wastes",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_01_p2_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Sabaton of the Wastes"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/sabatons-of-akkhan",
+	"url_name": "sabatons-of-akkhan",
+	"api_url": "https://us.battle.net/api/d3/data/item/sabatons-of-akkhan",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_10_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Sabatons of Akkhan"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/sages-passage",
+	"url_name": "sages-passage",
+	"api_url": "https://us.battle.net/api/d3/data/item/sages-passage",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_018_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Sage's Passage"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/striders-of-destiny",
+	"url_name": "striders-of-destiny",
+	"api_url": "https://us.battle.net/api/d3/data/item/striders-of-destiny",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_02_p2_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Striders of Destiny"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-shadows-heels",
+	"url_name": "the-shadows-heels",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-shadows-heels",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_14_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "The Shadow's Heels"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/ulianas-destiny",
+	"url_name": "ulianas-destiny",
+	"api_url": "https://us.battle.net/api/d3/data/item/ulianas-destiny",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_01_p3_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Uliana's Destiny"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/vyrs-swaggering-stance",
+	"url_name": "vyrs-swaggering-stance",
+	"api_url": "https://us.battle.net/api/d3/data/item/vyrs-swaggering-stance",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_13_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Vyr's Swaggering Stance"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/zeal-of-the-invoker",
+	"url_name": "zeal-of-the-invoker",
+	"api_url": "https://us.battle.net/api/d3/data/item/zeal-of-the-invoker",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_boots_set_12_x1_demonhunter_male.png",
+	"type": "boots",
+	"quality": "set",
+	"name": "Zeal of the Invoker"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/jeweler/recipe/hellfire-amulet-of-strength",
+	"url_name": "hellfire-amulet-of-strength",
+	"api_url": "https://us.battle.net/api/d3/data/item/hellfire-amulet-of-strength",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/x1_amulet_norm_unique_25_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "Hellfire Amulet"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/jeweler/recipe/hellfire-amulet-of-intelligence",
+	"url_name": "hellfire-amulet-of-intelligence",
+	"api_url": "https://us.battle.net/api/d3/data/item/hellfire-amulet-of-intelligence",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/x1_amulet_norm_unique_25_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "Hellfire Amulet"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/jeweler/recipe/hellfire-amulet-of-dexterity",
+	"url_name": "hellfire-amulet-of-dexterity",
+	"api_url": "https://us.battle.net/api/d3/data/item/hellfire-amulet-of-dexterity",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/x1_amulet_norm_unique_25_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "Hellfire Amulet"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/moonlight-ward",
+	"url_name": "moonlight-ward",
+	"api_url": "https://us.battle.net/api/d3/data/item/moonlight-ward",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_003_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "Moonlight Ward"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/squirts-necklace",
+	"url_name": "squirts-necklace",
+	"api_url": "https://us.battle.net/api/d3/data/item/squirts-necklace",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_010_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "Squirt's Necklace"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/golden-gorget-of-leoric",
+	"url_name": "golden-gorget-of-leoric",
+	"api_url": "https://us.battle.net/api/d3/data/item/golden-gorget-of-leoric",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_105_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "Golden Gorget of Leoric"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/overwhelming-desire",
+	"url_name": "overwhelming-desire",
+	"api_url": "https://us.battle.net/api/d3/data/item/overwhelming-desire",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_106_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "Overwhelming Desire"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/eye-of-etlich",
+	"url_name": "eye-of-etlich",
+	"api_url": "https://us.battle.net/api/d3/data/item/eye-of-etlich",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_014_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "Eye of Etlich"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/rondals-locket",
+	"url_name": "rondals-locket",
+	"api_url": "https://us.battle.net/api/d3/data/item/rondals-locket",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_009_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "Rondal's Locket"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/talisman-of-aranoch",
+	"url_name": "talisman-of-aranoch",
+	"api_url": "https://us.battle.net/api/d3/data/item/talisman-of-aranoch",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_012_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "Talisman of Aranoch"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/ancestors-grace",
+	"url_name": "ancestors-grace",
+	"api_url": "https://us.battle.net/api/d3/data/item/ancestors-grace",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_102_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "Ancestors' Grace"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/countess-julias-cameo",
+	"url_name": "countess-julias-cameo",
+	"api_url": "https://us.battle.net/api/d3/data/item/countess-julias-cameo",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_103_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "Countess Julia's Cameo"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/dovu-energy-trap",
+	"url_name": "dovu-energy-trap",
+	"api_url": "https://us.battle.net/api/d3/data/item/dovu-energy-trap",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_107_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "Dovu Energy Trap"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/haunt-of-vaxo",
+	"url_name": "haunt-of-vaxo",
+	"api_url": "https://us.battle.net/api/d3/data/item/haunt-of-vaxo",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_101_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "Haunt of Vaxo"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/rakoffs-glass-of-life",
+	"url_name": "rakoffs-glass-of-life",
+	"api_url": "https://us.battle.net/api/d3/data/item/rakoffs-glass-of-life",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_108_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "Rakoff's Glass of Life"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-ess-of-johan",
+	"url_name": "the-ess-of-johan",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-ess-of-johan",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_104_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "The Ess of Johan"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/holy-beacon",
+	"url_name": "holy-beacon",
+	"api_url": "https://us.battle.net/api/d3/data/item/holy-beacon",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_013_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "Holy Beacon"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/kymbos-gold",
+	"url_name": "kymbos-gold",
+	"api_url": "https://us.battle.net/api/d3/data/item/kymbos-gold",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_002_p1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "Kymbo's Gold"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-flavor-of-time",
+	"url_name": "the-flavor-of-time",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-flavor-of-time",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_001_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "The Flavor of Time"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/maras-kaleidoscope",
+	"url_name": "maras-kaleidoscope",
+	"api_url": "https://us.battle.net/api/d3/data/item/maras-kaleidoscope",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_015_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "Mara's Kaleidoscope"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/ouroboros",
+	"url_name": "ouroboros",
+	"api_url": "https://us.battle.net/api/d3/data/item/ouroboros",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_005_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "Ouroboros"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-star-of-azkaranth",
+	"url_name": "the-star-of-azkaranth",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-star-of-azkaranth",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_006_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "The Star of Azkaranth"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/xephirian-amulet",
+	"url_name": "xephirian-amulet",
+	"api_url": "https://us.battle.net/api/d3/data/item/xephirian-amulet",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_004_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "Xephirian Amulet"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/blackthornes-duncraig-cross",
+	"url_name": "blackthornes-duncraig-cross",
+	"api_url": "https://us.battle.net/api/d3/data/item/blackthornes-duncraig-cross",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_016_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "set",
+	"name": "Blackthorne's Duncraig Cross"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/tal-rashas-allegiance",
+	"url_name": "tal-rashas-allegiance",
+	"api_url": "https://us.battle.net/api/d3/data/item/tal-rashas-allegiance",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_007_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "set",
+	"name": "Tal Rasha's Allegiance"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-travelers-pledge",
+	"url_name": "the-travelers-pledge",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-travelers-pledge",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_008_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "set",
+	"name": "The Traveler's Pledge"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/halcyons-ascent",
+	"url_name": "halcyons-ascent",
+	"api_url": "https://us.battle.net/api/d3/data/item/halcyons-ascent",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_109_x1_210_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "legendary",
+	"name": "Halcyon's Ascent"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/sunwukos-shines",
+	"url_name": "sunwukos-shines",
+	"api_url": "https://us.battle.net/api/d3/data/item/sunwukos-shines",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_amulet_set_11_x1_demonhunter_male.png",
+	"type": "amulet",
+	"quality": "set",
+	"name": "Sunwuko's Shines"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/jeweler/recipe/hellfire-ring-of-strength",
+	"url_name": "hellfire-ring-of-strength",
+	"api_url": "https://us.battle.net/api/d3/data/item/hellfire-ring-of-strength",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_024_104_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Hellfire Ring"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/jeweler/recipe/hellfire-ring-of-intelligence",
+	"url_name": "hellfire-ring-of-intelligence",
+	"api_url": "https://us.battle.net/api/d3/data/item/hellfire-ring-of-intelligence",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_024_104_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Hellfire Ring"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/jeweler/recipe/hellfire-ring-of-vitality",
+	"url_name": "hellfire-ring-of-vitality",
+	"api_url": "https://us.battle.net/api/d3/data/item/hellfire-ring-of-vitality",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_024_104_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Hellfire Ring"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/jeweler/recipe/hellfire-ring-of-dexterity",
+	"url_name": "hellfire-ring-of-dexterity",
+	"api_url": "https://us.battle.net/api/d3/data/item/hellfire-ring-of-dexterity",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_024_104_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Hellfire Ring"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/jeweler/recipe/hellfire-ring",
+	"url_name": "hellfire-ring",
+	"api_url": "https://us.battle.net/api/d3/data/item/hellfire-ring",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_024_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Hellfire Ring"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/band-of-might",
+	"url_name": "band-of-might",
+	"api_url": "https://us.battle.net/api/d3/data/item/band-of-might",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_ring_05_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Band of Might"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/manald-heal",
+	"url_name": "manald-heal",
+	"api_url": "https://us.battle.net/api/d3/data/item/manald-heal",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_021_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Manald Heal"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/avarice-band",
+	"url_name": "avarice-band",
+	"api_url": "https://us.battle.net/api/d3/data/item/avarice-band",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_108_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Avarice Band"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/leorics-signet",
+	"url_name": "leorics-signet",
+	"api_url": "https://us.battle.net/api/d3/data/item/leorics-signet",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_002_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Leoric's Signet"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/pandemonium-loop",
+	"url_name": "pandemonium-loop",
+	"api_url": "https://us.battle.net/api/d3/data/item/pandemonium-loop",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_109_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Pandemonium Loop"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/ring-of-royal-grandeur",
+	"url_name": "ring-of-royal-grandeur",
+	"api_url": "https://us.battle.net/api/d3/data/item/ring-of-royal-grandeur",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_107_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Ring of Royal Grandeur"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/broken-promises",
+	"url_name": "broken-promises",
+	"api_url": "https://us.battle.net/api/d3/data/item/broken-promises",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_006_p2_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Broken Promises"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/puzzle-ring",
+	"url_name": "puzzle-ring",
+	"api_url": "https://us.battle.net/api/d3/data/item/puzzle-ring",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_004_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Puzzle Ring"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/arcstone",
+	"url_name": "arcstone",
+	"api_url": "https://us.battle.net/api/d3/data/item/arcstone",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_ring_03_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Arcstone"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/band-of-the-rue-chambers",
+	"url_name": "band-of-the-rue-chambers",
+	"api_url": "https://us.battle.net/api/d3/data/item/band-of-the-rue-chambers",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_106_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Band of the Rue Chambers"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/rechels-ring-of-larceny",
+	"url_name": "rechels-ring-of-larceny",
+	"api_url": "https://us.battle.net/api/d3/data/item/rechels-ring-of-larceny",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_104_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Rechel's Ring of Larceny"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/rogars-huge-stone",
+	"url_name": "rogars-huge-stone",
+	"api_url": "https://us.battle.net/api/d3/data/item/rogars-huge-stone",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_103_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Rogar's Huge Stone"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-short-mans-finger",
+	"url_name": "the-short-mans-finger",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-short-mans-finger",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_ring_02_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "The Short Man's Finger"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-tall-mans-finger",
+	"url_name": "the-tall-mans-finger",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-tall-mans-finger",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_101_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "The Tall Man's Finger"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/wyrdward",
+	"url_name": "wyrdward",
+	"api_url": "https://us.battle.net/api/d3/data/item/wyrdward",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_102_p2_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Wyrdward"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/nagelring",
+	"url_name": "nagelring",
+	"api_url": "https://us.battle.net/api/d3/data/item/nagelring",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_018_p2_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Nagelring"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/bulkathoss-wedding-band",
+	"url_name": "bulkathoss-wedding-band",
+	"api_url": "https://us.battle.net/api/d3/data/item/bulkathoss-wedding-band",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_020_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Bul-Kathos's Wedding Band"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/eternal-union",
+	"url_name": "eternal-union",
+	"api_url": "https://us.battle.net/api/d3/data/item/eternal-union",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_007_p1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Eternal Union"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/justice-lantern",
+	"url_name": "justice-lantern",
+	"api_url": "https://us.battle.net/api/d3/data/item/justice-lantern",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_ring_03_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Justice Lantern"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/obsidian-ring-of-the-zodiac",
+	"url_name": "obsidian-ring-of-the-zodiac",
+	"api_url": "https://us.battle.net/api/d3/data/item/obsidian-ring-of-the-zodiac",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_023_p2_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Obsidian Ring of the Zodiac"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/convention-of-elements",
+	"url_name": "convention-of-elements",
+	"api_url": "https://us.battle.net/api/d3/data/item/convention-of-elements",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_ring_04_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Convention of Elements"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/elusive-ring",
+	"url_name": "elusive-ring",
+	"api_url": "https://us.battle.net/api/d3/data/item/elusive-ring",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_ring_02_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Elusive Ring"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/halo-of-arlyse",
+	"url_name": "halo-of-arlyse",
+	"api_url": "https://us.battle.net/api/d3/data/item/halo-of-arlyse",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_ring_wizard_001_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Halo of Arlyse"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/ring-of-emptiness",
+	"url_name": "ring-of-emptiness",
+	"api_url": "https://us.battle.net/api/d3/data/item/ring-of-emptiness",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_ring_01_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Ring of Emptiness "
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/band-of-hollow-whispers",
+	"url_name": "band-of-hollow-whispers",
+	"api_url": "https://us.battle.net/api/d3/data/item/band-of-hollow-whispers",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_001_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Band of Hollow Whispers"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/kredes-flame",
+	"url_name": "kredes-flame",
+	"api_url": "https://us.battle.net/api/d3/data/item/kredes-flame",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_003_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Krede's Flame"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/oculus-ring",
+	"url_name": "oculus-ring",
+	"api_url": "https://us.battle.net/api/d3/data/item/oculus-ring",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_017_p4_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Oculus Ring"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/skull-grasp",
+	"url_name": "skull-grasp",
+	"api_url": "https://us.battle.net/api/d3/data/item/skull-grasp",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_ring_01_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Skull Grasp"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/stone-of-jordan",
+	"url_name": "stone-of-jordan",
+	"api_url": "https://us.battle.net/api/d3/data/item/stone-of-jordan",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_019_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Stone of Jordan"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/unity",
+	"url_name": "unity",
+	"api_url": "https://us.battle.net/api/d3/data/item/unity",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_010_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "legendary",
+	"name": "Unity"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/litany-of-the-undaunted",
+	"url_name": "litany-of-the-undaunted",
+	"api_url": "https://us.battle.net/api/d3/data/item/litany-of-the-undaunted",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_015_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "set",
+	"name": "Litany of the Undaunted"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/natalyas-reflection",
+	"url_name": "natalyas-reflection",
+	"api_url": "https://us.battle.net/api/d3/data/item/natalyas-reflection",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_011_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "set",
+	"name": "Natalya's Reflection"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-compass-rose",
+	"url_name": "the-compass-rose",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-compass-rose",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_013_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "set",
+	"name": "The Compass Rose"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-wailing-host",
+	"url_name": "the-wailing-host",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-wailing-host",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_014_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "set",
+	"name": "The Wailing Host"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/zunimassas-pox",
+	"url_name": "zunimassas-pox",
+	"api_url": "https://us.battle.net/api/d3/data/item/zunimassas-pox",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_012_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "set",
+	"name": "Zunimassa's Pox"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/focus",
+	"url_name": "focus",
+	"api_url": "https://us.battle.net/api/d3/data/item/focus",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_set_001_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "set",
+	"name": "Focus"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/restraint",
+	"url_name": "restraint",
+	"api_url": "https://us.battle.net/api/d3/data/item/restraint",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ring_set_002_x1_demonhunter_male.png",
+	"type": "ring",
+	"quality": "set",
+	"name": "Restraint"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/covens-criterion",
+	"url_name": "covens-criterion",
+	"api_url": "https://us.battle.net/api/d3/data/item/covens-criterion",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_107_x1_demonhunter_male.png",
+	"type": "shield",
+	"quality": "legendary",
+	"name": "Coven's Criterion"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/denial",
+	"url_name": "denial",
+	"api_url": "https://us.battle.net/api/d3/data/item/denial",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_shield_007_demonhunter_male.png",
+	"type": "shield",
+	"quality": "legendary",
+	"name": "Denial"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/wall-of-bone",
+	"url_name": "wall-of-bone",
+	"api_url": "https://us.battle.net/api/d3/data/item/wall-of-bone",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_011_1xx_demonhunter_male.png",
+	"type": "shield",
+	"quality": "legendary",
+	"name": "Wall of Bone"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/defender-of-westmarch",
+	"url_name": "defender-of-westmarch",
+	"api_url": "https://us.battle.net/api/d3/data/item/defender-of-westmarch",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_101_p2_demonhunter_male.png",
+	"type": "shield",
+	"quality": "legendary",
+	"name": "Defender of Westmarch"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/eberli-charo",
+	"url_name": "eberli-charo",
+	"api_url": "https://us.battle.net/api/d3/data/item/eberli-charo",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_102_x1_demonhunter_male.png",
+	"type": "shield",
+	"quality": "legendary",
+	"name": "Eberli Charo"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/freeze-of-deflection",
+	"url_name": "freeze-of-deflection",
+	"api_url": "https://us.battle.net/api/d3/data/item/freeze-of-deflection",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_004_x1_demonhunter_male.png",
+	"type": "shield",
+	"quality": "legendary",
+	"name": "Freeze of Deflection"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/votoyias-spiker",
+	"url_name": "votoyias-spiker",
+	"api_url": "https://us.battle.net/api/d3/data/item/votoyias-spiker",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_104_x1_demonhunter_male.png",
+	"type": "shield",
+	"quality": "legendary",
+	"name": "Vo'Toyias Spiker"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/lidless-wall",
+	"url_name": "lidless-wall",
+	"api_url": "https://us.battle.net/api/d3/data/item/lidless-wall",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_008_x1_demonhunter_male.png",
+	"type": "shield",
+	"quality": "legendary",
+	"name": "Lidless Wall"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/ivory-tower",
+	"url_name": "ivory-tower",
+	"api_url": "https://us.battle.net/api/d3/data/item/ivory-tower",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_shield_002_demonhunter_male.png",
+	"type": "shield",
+	"quality": "legendary",
+	"name": "Ivory Tower"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/stormshield",
+	"url_name": "stormshield",
+	"api_url": "https://us.battle.net/api/d3/data/item/stormshield",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_009_x1_demonhunter_male.png",
+	"type": "shield",
+	"quality": "legendary",
+	"name": "Stormshield"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-barrier",
+	"url_name": "hallowed-barrier",
+	"api_url": "https://us.battle.net/api/d3/data/item/hallowed-barrier",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_012_1xx_demonhunter_male.png",
+	"type": "shield",
+	"quality": "set",
+	"name": "Hallowed Defender"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/wall-of-man",
+	"url_name": "wall-of-man",
+	"api_url": "https://us.battle.net/api/d3/data/item/wall-of-man",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_011_x1_demonhunter_male.png",
+	"type": "shield",
+	"quality": "legendary",
+	"name": "Wall of Man"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-barricade",
+	"url_name": "hallowed-barricade",
+	"api_url": "https://us.battle.net/api/d3/data/item/hallowed-barricade",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_012_x1_demonhunter_male.png",
+	"type": "shield",
+	"quality": "set",
+	"name": "Hallowed Barricade"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/guard-of-johanna",
+	"url_name": "guard-of-johanna",
+	"api_url": "https://us.battle.net/api/d3/data/item/guard-of-johanna",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_103_x1_demonhunter_male.png",
+	"type": "crusader-shield",
+	"quality": "legendary",
+	"name": "Guard of Johanna"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/salvation",
+	"url_name": "salvation",
+	"api_url": "https://us.battle.net/api/d3/data/item/salvation",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_crushield_108_x1_demonhunter_male.png",
+	"type": "crusader-shield",
+	"quality": "legendary",
+	"name": "Salvation"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/shield-of-fury",
+	"url_name": "shield-of-fury",
+	"api_url": "https://us.battle.net/api/d3/data/item/shield-of-fury",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_shield_106_x1_demonhunter_male.png",
+	"type": "crusader-shield",
+	"quality": "legendary",
+	"name": "Shield of Fury"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/akarats-awakening",
+	"url_name": "akarats-awakening",
+	"api_url": "https://us.battle.net/api/d3/data/item/akarats-awakening",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_crushield_104_x1_demonhunter_male.png",
+	"type": "crusader-shield",
+	"quality": "legendary",
+	"name": "Akarat's Awakening"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/hallowed-bulwark",
+	"url_name": "hallowed-bulwark",
+	"api_url": "https://us.battle.net/api/d3/data/item/hallowed-bulwark",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_crushield_103_x1_demonhunter_male.png",
+	"type": "crusader-shield",
+	"quality": "legendary",
+	"name": "Hallowed Bulwark"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/hellskull",
+	"url_name": "hellskull",
+	"api_url": "https://us.battle.net/api/d3/data/item/hellskull",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_crushield_105_x1_demonhunter_male.png",
+	"type": "crusader-shield",
+	"quality": "legendary",
+	"name": "Hellskull"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/jekangbord",
+	"url_name": "jekangbord",
+	"api_url": "https://us.battle.net/api/d3/data/item/jekangbord",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_crushield_102_x1_demonhunter_male.png",
+	"type": "crusader-shield",
+	"quality": "legendary",
+	"name": "Jekangbord"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/sublime-conviction",
+	"url_name": "sublime-conviction",
+	"api_url": "https://us.battle.net/api/d3/data/item/sublime-conviction",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_crushield_106_x1_demonhunter_male.png",
+	"type": "crusader-shield",
+	"quality": "legendary",
+	"name": "Sublime Conviction"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-final-witness",
+	"url_name": "the-final-witness",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-final-witness",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_crushield_107_x1_demonhunter_male.png",
+	"type": "crusader-shield",
+	"quality": "legendary",
+	"name": "The Final Witness"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/frydehrs-wrath",
+	"url_name": "frydehrs-wrath",
+	"api_url": "https://us.battle.net/api/d3/data/item/frydehrs-wrath",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p1_crushield_norm_unique_01_demonhunter_male.png",
+	"type": "crusader-shield",
+	"quality": "legendary",
+	"name": "Frydehr's Wrath"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/piro-marella",
+	"url_name": "piro-marella",
+	"api_url": "https://us.battle.net/api/d3/data/item/piro-marella",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_crushield_101_x1_demonhunter_male.png",
+	"type": "crusader-shield",
+	"quality": "legendary",
+	"name": "Piro Marella"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/unrelenting-phalanx",
+	"url_name": "unrelenting-phalanx",
+	"api_url": "https://us.battle.net/api/d3/data/item/unrelenting-phalanx",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p1_crushield_norm_unique_02_demonhunter_male.png",
+	"type": "crusader-shield",
+	"quality": "legendary",
+	"name": "Unrelenting Phalanx"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/shield-of-the-steed",
+	"url_name": "shield-of-the-steed",
+	"api_url": "https://us.battle.net/api/d3/data/item/shield-of-the-steed",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_shield_set_01_x1_demonhunter_male.png",
+	"type": "crusader-shield",
+	"quality": "set",
+	"name": "Shield of the Steed"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/gazing-demise",
+	"url_name": "gazing-demise",
+	"api_url": "https://us.battle.net/api/d3/data/item/gazing-demise",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mojo_003_x1_demonhunter_male.png",
+	"type": "mojo",
+	"quality": "legendary",
+	"name": "Gazing Demise"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/homunculus",
+	"url_name": "homunculus",
+	"api_url": "https://us.battle.net/api/d3/data/item/homunculus",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mojo_004_p2_demonhunter_male.png",
+	"type": "mojo",
+	"quality": "legendary",
+	"name": "Homunculus"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/bitterness",
+	"url_name": "bitterness",
+	"api_url": "https://us.battle.net/api/d3/data/item/bitterness",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mojo_002_1xx_demonhunter_male.png",
+	"type": "mojo",
+	"quality": "legendary",
+	"name": "Bitterness"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/shukranis-triumph",
+	"url_name": "shukranis-triumph",
+	"api_url": "https://us.battle.net/api/d3/data/item/shukranis-triumph",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mojo_102_x1_demonhunter_male.png",
+	"type": "mojo",
+	"quality": "legendary",
+	"name": "Shukrani's Triumph"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/thing-of-the-deep",
+	"url_name": "thing-of-the-deep",
+	"api_url": "https://us.battle.net/api/d3/data/item/thing-of-the-deep",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_mojo_002_demonhunter_male.png",
+	"type": "mojo",
+	"quality": "legendary",
+	"name": "Thing of the Deep"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/uhkapian-serpent",
+	"url_name": "uhkapian-serpent",
+	"api_url": "https://us.battle.net/api/d3/data/item/uhkapian-serpent",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mojo_008_x1_demonhunter_male.png",
+	"type": "mojo",
+	"quality": "legendary",
+	"name": "Uhkapian Serpent"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/manajumas-gory-fetch",
+	"url_name": "manajumas-gory-fetch",
+	"api_url": "https://us.battle.net/api/d3/data/item/manajumas-gory-fetch",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mojo_010_x1_demonhunter_male.png",
+	"type": "mojo",
+	"quality": "set",
+	"name": "Manajuma's Gory Fetch"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/zunimassas-string-of-skulls",
+	"url_name": "zunimassas-string-of-skulls",
+	"api_url": "https://us.battle.net/api/d3/data/item/zunimassas-string-of-skulls",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mojo_011_x1_demonhunter_male.png",
+	"type": "mojo",
+	"quality": "set",
+	"name": "Zunimassa's String of Skulls"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/henris-perquisition",
+	"url_name": "henris-perquisition",
+	"api_url": "https://us.battle.net/api/d3/data/item/henris-perquisition",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_mojo_norm_unique_02_demonhunter_male.png",
+	"type": "mojo",
+	"quality": "legendary",
+	"name": "Henri’s Perquisition"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/spite",
+	"url_name": "spite",
+	"api_url": "https://us.battle.net/api/d3/data/item/spite",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mojo_002_x1_demonhunter_male.png",
+	"type": "mojo",
+	"quality": "legendary",
+	"name": "Spite"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/vile-hive",
+	"url_name": "vile-hive",
+	"api_url": "https://us.battle.net/api/d3/data/item/vile-hive",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_mojo_001_demonhunter_male.png",
+	"type": "mojo",
+	"quality": "legendary",
+	"name": "Vile Hive"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/wilkens-reach",
+	"url_name": "wilkens-reach",
+	"api_url": "https://us.battle.net/api/d3/data/item/wilkens-reach",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_mojo_003_demonhunter_male.png",
+	"type": "mojo",
+	"quality": "legendary",
+	"name": "Wilken's Reach"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/winter-flurry",
+	"url_name": "winter-flurry",
+	"api_url": "https://us.battle.net/api/d3/data/item/winter-flurry",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_orb_005_x1_demonhunter_male.png",
+	"type": "orb",
+	"quality": "legendary",
+	"name": "Winter Flurry"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/etched-sigil",
+	"url_name": "etched-sigil",
+	"api_url": "https://us.battle.net/api/d3/data/item/etched-sigil",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_orb_002_demonhunter_male.png",
+	"type": "orb",
+	"quality": "legendary",
+	"name": "Etched Sigil"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/light-of-grace",
+	"url_name": "light-of-grace",
+	"api_url": "https://us.battle.net/api/d3/data/item/light-of-grace",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_orb_103_x1_demonhunter_male.png",
+	"type": "orb",
+	"quality": "legendary",
+	"name": "Light of Grace"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/mirrorball",
+	"url_name": "mirrorball",
+	"api_url": "https://us.battle.net/api/d3/data/item/mirrorball",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_orb_101_x1_demonhunter_male.png",
+	"type": "orb",
+	"quality": "legendary",
+	"name": "Mirrorball"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/mykens-ball-of-hate",
+	"url_name": "mykens-ball-of-hate",
+	"api_url": "https://us.battle.net/api/d3/data/item/mykens-ball-of-hate",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_orb_102_x1_demonhunter_male.png",
+	"type": "orb",
+	"quality": "legendary",
+	"name": "Myken's Ball of Hate"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/singularity",
+	"url_name": "singularity",
+	"api_url": "https://us.battle.net/api/d3/data/item/singularity",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_orb_004_1xx_demonhunter_male.png",
+	"type": "orb",
+	"quality": "legendary",
+	"name": "Singularity"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-oculus",
+	"url_name": "the-oculus",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-oculus",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_orb_001_x1_demonhunter_male.png",
+	"type": "orb",
+	"quality": "legendary",
+	"name": "The Oculus"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/triumvirate",
+	"url_name": "triumvirate",
+	"api_url": "https://us.battle.net/api/d3/data/item/triumvirate",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_orb_003_demonhunter_male.png",
+	"type": "orb",
+	"quality": "legendary",
+	"name": "Triumvirate"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/chantodos-force",
+	"url_name": "chantodos-force",
+	"api_url": "https://us.battle.net/api/d3/data/item/chantodos-force",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_orb_011_x1_demonhunter_male.png",
+	"type": "orb",
+	"quality": "set",
+	"name": "Chantodo's Force"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/tal-rashas-unwavering-glare",
+	"url_name": "tal-rashas-unwavering-glare",
+	"api_url": "https://us.battle.net/api/d3/data/item/tal-rashas-unwavering-glare",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_orb_012_x1_demonhunter_male.png",
+	"type": "orb",
+	"quality": "set",
+	"name": "Tal Rasha's Unwavering Glare"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/primordial-soul",
+	"url_name": "primordial-soul",
+	"api_url": "https://us.battle.net/api/d3/data/item/primordial-soul",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_orb_001_demonhunter_male.png",
+	"type": "orb",
+	"quality": "legendary",
+	"name": "Primordial Soul"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/cosmic-strand",
+	"url_name": "cosmic-strand",
+	"api_url": "https://us.battle.net/api/d3/data/item/cosmic-strand",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_orb_004_x1_demonhunter_male.png",
+	"type": "orb",
+	"quality": "legendary",
+	"name": "Cosmic Strand"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/orb-of-infinite-depth",
+	"url_name": "orb-of-infinite-depth",
+	"api_url": "https://us.battle.net/api/d3/data/item/orb-of-infinite-depth",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_orb_004_demonhunter_male.png",
+	"type": "orb",
+	"quality": "legendary",
+	"name": "Orb of Infinite Depth"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/firebirds-eye",
+	"url_name": "firebirds-eye",
+	"api_url": "https://us.battle.net/api/d3/data/item/firebirds-eye",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_orb_set_06_x1_demonhunter_male.png",
+	"type": "orb",
+	"quality": "set",
+	"name": "Firebird's Eye"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/fletchers-pride",
+	"url_name": "fletchers-pride",
+	"api_url": "https://us.battle.net/api/d3/data/item/fletchers-pride",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_quiver_006_x1_demonhunter_male.png",
+	"type": "quiver",
+	"quality": "legendary",
+	"name": "Fletcher's Pride"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/sin-seekers",
+	"url_name": "sin-seekers",
+	"api_url": "https://us.battle.net/api/d3/data/item/sin-seekers",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_quiver_001_demonhunter_male.png",
+	"type": "quiver",
+	"quality": "legendary",
+	"name": "Sin Seekers"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/holy-point-shot",
+	"url_name": "holy-point-shot",
+	"api_url": "https://us.battle.net/api/d3/data/item/holy-point-shot",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_quiver_004_x1_demonhunter_male.png",
+	"type": "quiver",
+	"quality": "legendary",
+	"name": "Holy Point Shot"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/spines-of-seething-hatred",
+	"url_name": "spines-of-seething-hatred",
+	"api_url": "https://us.battle.net/api/d3/data/item/spines-of-seething-hatred",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_quiver_005_p1_demonhunter_male.png",
+	"type": "quiver",
+	"quality": "legendary",
+	"name": "Spines of Seething Hatred"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/bombardiers-rucksack",
+	"url_name": "bombardiers-rucksack",
+	"api_url": "https://us.battle.net/api/d3/data/item/bombardiers-rucksack",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_quiver_102_x1_demonhunter_male.png",
+	"type": "quiver",
+	"quality": "legendary",
+	"name": "Bombardier's Rucksack"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/emimeis-duffel",
+	"url_name": "emimeis-duffel",
+	"api_url": "https://us.battle.net/api/d3/data/item/emimeis-duffel",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_quiver_103_x1_demonhunter_male.png",
+	"type": "quiver",
+	"quality": "legendary",
+	"name": "Emimei's Duffel"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-ninth-cirri-satchel",
+	"url_name": "the-ninth-cirri-satchel",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-ninth-cirri-satchel",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_quiver_101_x1_demonhunter_male.png",
+	"type": "quiver",
+	"quality": "legendary",
+	"name": "The Ninth Cirri Satchel"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/meticulous-bolts",
+	"url_name": "meticulous-bolts",
+	"api_url": "https://us.battle.net/api/d3/data/item/meticulous-bolts",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_quiver_001_p1_demonhunter_male.png",
+	"type": "quiver",
+	"quality": "legendary",
+	"name": "Meticulous Bolts"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/dead-mans-legacy",
+	"url_name": "dead-mans-legacy",
+	"api_url": "https://us.battle.net/api/d3/data/item/dead-mans-legacy",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_quiver_007_demonhunter_male.png",
+	"type": "quiver",
+	"quality": "legendary",
+	"name": "Dead Man's Legacy"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/black-bone-arrows",
+	"url_name": "black-bone-arrows",
+	"api_url": "https://us.battle.net/api/d3/data/item/black-bone-arrows",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_quiver_003_1xx_demonhunter_male.png",
+	"type": "quiver",
+	"quality": "legendary",
+	"name": "Black Bone Arrows"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/archfiend-arrows",
+	"url_name": "archfiend-arrows",
+	"api_url": "https://us.battle.net/api/d3/data/item/archfiend-arrows",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_quiver_003_x1_demonhunter_male.png",
+	"type": "quiver",
+	"quality": "legendary",
+	"name": "Archfiend Arrows"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/hand-of-the-prophet",
+	"url_name": "hand-of-the-prophet",
+	"api_url": "https://us.battle.net/api/d3/data/item/hand-of-the-prophet",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/x1_followeritem_enchantress_legendary_02_demonhunter_male.png",
+	"type": "enchantress-focus",
+	"quality": "legendary",
+	"name": "Hand of the Prophet"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/smoking-thurible",
+	"url_name": "smoking-thurible",
+	"api_url": "https://us.battle.net/api/d3/data/item/smoking-thurible",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/x1_followeritem_enchantress_legendary_01_demonhunter_male.png",
+	"type": "enchantress-focus",
+	"quality": "legendary",
+	"name": "Smoking Thurible"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/vadims-surge",
+	"url_name": "vadims-surge",
+	"api_url": "https://us.battle.net/api/d3/data/item/vadims-surge",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/x1_followeritem_enchantress_legendary_03_demonhunter_male.png",
+	"type": "enchantress-focus",
+	"quality": "legendary",
+	"name": "Vadim's Surge"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/ribald-etchings",
+	"url_name": "ribald-etchings",
+	"api_url": "https://us.battle.net/api/d3/data/item/ribald-etchings",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/x1_followeritem_scoundrel_legendary_02_demonhunter_male.png",
+	"type": "scoundrel-token",
+	"quality": "legendary",
+	"name": "Ribald Etchings"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/skeleton-key",
+	"url_name": "skeleton-key",
+	"api_url": "https://us.battle.net/api/d3/data/item/skeleton-key",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/x1_followeritem_scoundrel_legendary_01_demonhunter_male.png",
+	"type": "scoundrel-token",
+	"quality": "legendary",
+	"name": "Skeleton Key"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/slipkas-letter-opener",
+	"url_name": "slipkas-letter-opener",
+	"api_url": "https://us.battle.net/api/d3/data/item/slipkas-letter-opener",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/x1_followeritem_scoundrel_legendary_03_demonhunter_male.png",
+	"type": "scoundrel-token",
+	"quality": "legendary",
+	"name": "Slipka's Letter Opener"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/enchanting-favor",
+	"url_name": "enchanting-favor",
+	"api_url": "https://us.battle.net/api/d3/data/item/enchanting-favor",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/x1_followeritem_templar_legendary_01_demonhunter_male.png",
+	"type": "templar-relic",
+	"quality": "legendary",
+	"name": "Enchanting Favor"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/hillenbrands-training-sword",
+	"url_name": "hillenbrands-training-sword",
+	"api_url": "https://us.battle.net/api/d3/data/item/hillenbrands-training-sword",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/x1_followeritem_templar_legendary_03_demonhunter_male.png",
+	"type": "templar-relic",
+	"quality": "legendary",
+	"name": "Hillenbrand's Training Sword"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/relic-of-akarat",
+	"url_name": "relic-of-akarat",
+	"api_url": "https://us.battle.net/api/d3/data/item/relic-of-akarat",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/x1_followeritem_templar_legendary_02_demonhunter_male.png",
+	"type": "templar-relic",
+	"quality": "legendary",
+	"name": "Relic of Akarat"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/genzaniku",
+	"url_name": "genzaniku",
+	"api_url": "https://us.battle.net/api/d3/data/item/genzaniku",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_1h_003_x1_demonhunter_male.png",
+	"type": "axe-1h",
+	"quality": "legendary",
+	"name": "Genzaniku"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/flesh-tearer",
+	"url_name": "flesh-tearer",
+	"api_url": "https://us.battle.net/api/d3/data/item/flesh-tearer",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_1h_001_x1_demonhunter_male.png",
+	"type": "axe-1h",
+	"quality": "legendary",
+	"name": "Flesh Tearer"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/hack",
+	"url_name": "hack",
+	"api_url": "https://us.battle.net/api/d3/data/item/hack",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_1h_103_x1_demonhunter_male.png",
+	"type": "axe-1h",
+	"quality": "legendary",
+	"name": "Hack"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/the-wedge",
+	"url_name": "the-wedge",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-wedge",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_1h_004_1xx_demonhunter_male.png",
+	"type": "axe-1h",
+	"quality": "legendary",
+	"name": "The Wedge"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-butchers-sickle",
+	"url_name": "the-butchers-sickle",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-butchers-sickle",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_1h_006_x1_demonhunter_male.png",
+	"type": "axe-1h",
+	"quality": "legendary",
+	"name": "The Butcher's Sickle"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/sky-splitter",
+	"url_name": "sky-splitter",
+	"api_url": "https://us.battle.net/api/d3/data/item/sky-splitter",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_1h_005_p2_demonhunter_male.png",
+	"type": "axe-1h",
+	"quality": "legendary",
+	"name": "Sky Splitter"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-burning-axe-of-sankis",
+	"url_name": "the-burning-axe-of-sankis",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-burning-axe-of-sankis",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_1h_007_x1_demonhunter_male.png",
+	"type": "axe-1h",
+	"quality": "legendary",
+	"name": "The Burning Axe of Sankis"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-divide",
+	"url_name": "hallowed-divide",
+	"api_url": "https://us.battle.net/api/d3/data/item/hallowed-divide",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_1h_013_1xx_demonhunter_male.png",
+	"type": "axe-1h",
+	"quality": "set",
+	"name": "Hallowed Storm"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/mordullus-promise",
+	"url_name": "mordullus-promise",
+	"api_url": "https://us.battle.net/api/d3/data/item/mordullus-promise",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_axe_1h_102_demonhunter_male.png",
+	"type": "axe-1h",
+	"quality": "legendary",
+	"name": "Mordullu's Promise"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/utars-roar",
+	"url_name": "utars-roar",
+	"api_url": "https://us.battle.net/api/d3/data/item/utars-roar",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_1h_004_x1_demonhunter_male.png",
+	"type": "axe-1h",
+	"quality": "legendary",
+	"name": "Utar's Roar"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-breach",
+	"url_name": "hallowed-breach",
+	"api_url": "https://us.battle.net/api/d3/data/item/hallowed-breach",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_1h_013_x1_demonhunter_male.png",
+	"type": "axe-1h",
+	"quality": "set",
+	"name": "Hallowed Breach"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-barber",
+	"url_name": "the-barber",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-barber",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_dagger_003_x1_demonhunter_male.png",
+	"type": "dagger",
+	"quality": "legendary",
+	"name": "The Barber"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/envious-blade",
+	"url_name": "envious-blade",
+	"api_url": "https://us.battle.net/api/d3/data/item/envious-blade",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_dagger_103_x1_demonhunter_male.png",
+	"type": "dagger",
+	"quality": "legendary",
+	"name": "Envious Blade"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/pig-sticker",
+	"url_name": "pig-sticker",
+	"api_url": "https://us.battle.net/api/d3/data/item/pig-sticker",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_dagger_007_x1_demonhunter_male.png",
+	"type": "dagger",
+	"quality": "legendary",
+	"name": "Pig Sticker"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/wizardspike",
+	"url_name": "wizardspike",
+	"api_url": "https://us.battle.net/api/d3/data/item/wizardspike",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_dagger_010_x1_210_demonhunter_male.png",
+	"type": "dagger",
+	"quality": "legendary",
+	"name": "Wizardspike"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/bloodmagic-blade",
+	"url_name": "bloodmagic-blade",
+	"api_url": "https://us.battle.net/api/d3/data/item/bloodmagic-blade",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_dagger_006_1xx_demonhunter_male.png",
+	"type": "dagger",
+	"quality": "legendary",
+	"name": "Blood-Magic Blade"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/bloodmagic-edge",
+	"url_name": "bloodmagic-edge",
+	"api_url": "https://us.battle.net/api/d3/data/item/bloodmagic-edge",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_dagger_006_x1_demonhunter_male.png",
+	"type": "dagger",
+	"quality": "legendary",
+	"name": "Blood-Magic Edge"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/eunjangdo",
+	"url_name": "eunjangdo",
+	"api_url": "https://us.battle.net/api/d3/data/item/eunjangdo",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_dagger_104_x1_demonhunter_male.png",
+	"type": "dagger",
+	"quality": "legendary",
+	"name": "Eun-jang-do"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/karleis-point",
+	"url_name": "karleis-point",
+	"api_url": "https://us.battle.net/api/d3/data/item/karleis-point",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_dagger_101_x1_demonhunter_male.png",
+	"type": "dagger",
+	"quality": "legendary",
+	"name": "Karlei's Point"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/lord-greenstones-fan",
+	"url_name": "lord-greenstones-fan",
+	"api_url": "https://us.battle.net/api/d3/data/item/lord-greenstones-fan",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_dagger_102_x1_demonhunter_male.png",
+	"type": "dagger",
+	"quality": "legendary",
+	"name": "Lord Greenstone's Fan"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/odyn-son",
+	"url_name": "odyn-son",
+	"api_url": "https://us.battle.net/api/d3/data/item/odyn-son",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_002_x1_demonhunter_male.png",
+	"type": "mace-1h",
+	"quality": "legendary",
+	"name": "Odyn Son"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/mad-monarchs-scepter",
+	"url_name": "mad-monarchs-scepter",
+	"api_url": "https://us.battle.net/api/d3/data/item/mad-monarchs-scepter",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_101_x1_demonhunter_male.png",
+	"type": "mace-1h",
+	"quality": "legendary",
+	"name": "Mad Monarch's Scepter"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/nutcracker",
+	"url_name": "nutcracker",
+	"api_url": "https://us.battle.net/api/d3/data/item/nutcracker",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_005_x1_demonhunter_male.png",
+	"type": "mace-1h",
+	"quality": "legendary",
+	"name": "Nutcracker"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/telrandens-hand",
+	"url_name": "telrandens-hand",
+	"api_url": "https://us.battle.net/api/d3/data/item/telrandens-hand",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_007_x1_demonhunter_male.png",
+	"type": "mace-1h",
+	"quality": "legendary",
+	"name": "Telranden's Hand"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/jaces-hammer-of-vigilance",
+	"url_name": "jaces-hammer-of-vigilance",
+	"api_url": "https://us.battle.net/api/d3/data/item/jaces-hammer-of-vigilance",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_103_x1_demonhunter_male.png",
+	"type": "mace-1h",
+	"quality": "legendary",
+	"name": "Jace's Hammer of Vigilance"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/solanium",
+	"url_name": "solanium",
+	"api_url": "https://us.battle.net/api/d3/data/item/solanium",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_102_x1_demonhunter_male.png",
+	"type": "mace-1h",
+	"quality": "legendary",
+	"name": "Solanium"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/nailbiter",
+	"url_name": "nailbiter",
+	"api_url": "https://us.battle.net/api/d3/data/item/nailbiter",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_008_x1_demonhunter_male.png",
+	"type": "mace-1h",
+	"quality": "legendary",
+	"name": "Nailbiter"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/neanderthal",
+	"url_name": "neanderthal",
+	"api_url": "https://us.battle.net/api/d3/data/item/neanderthal",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_003_x1_demonhunter_male.png",
+	"type": "mace-1h",
+	"quality": "legendary",
+	"name": "Neanderthal"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/echoing-fury",
+	"url_name": "echoing-fury",
+	"api_url": "https://us.battle.net/api/d3/data/item/echoing-fury",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_001_x1_demonhunter_male.png",
+	"type": "mace-1h",
+	"quality": "legendary",
+	"name": "Echoing Fury"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/sun-keeper",
+	"url_name": "sun-keeper",
+	"api_url": "https://us.battle.net/api/d3/data/item/sun-keeper",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_011_x1_demonhunter_male.png",
+	"type": "mace-1h",
+	"quality": "legendary",
+	"name": "Sun Keeper"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/earthshatter",
+	"url_name": "earthshatter",
+	"api_url": "https://us.battle.net/api/d3/data/item/earthshatter",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_009_1xx_demonhunter_male.png",
+	"type": "mace-1h",
+	"quality": "legendary",
+	"name": "Earthshatter"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/devastator",
+	"url_name": "devastator",
+	"api_url": "https://us.battle.net/api/d3/data/item/devastator",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_1h_009_x1_demonhunter_male.png",
+	"type": "mace-1h",
+	"quality": "legendary",
+	"name": "Devastator"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/arreats-law",
+	"url_name": "arreats-law",
+	"api_url": "https://us.battle.net/api/d3/data/item/arreats-law",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_spear_001_demonhunter_male.png",
+	"type": "spear",
+	"quality": "legendary",
+	"name": "Arreat's Law"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/scrimshaw",
+	"url_name": "scrimshaw",
+	"api_url": "https://us.battle.net/api/d3/data/item/scrimshaw",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spear_004_p3_demonhunter_male.png",
+	"type": "spear",
+	"quality": "legendary",
+	"name": "Scrimshaw"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-three-hundredth-spear",
+	"url_name": "the-three-hundredth-spear",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-three-hundredth-spear",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_spear_002_demonhunter_male.png",
+	"type": "spear",
+	"quality": "legendary",
+	"name": "The Three Hundredth Spear"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/empyrean-messenger",
+	"url_name": "empyrean-messenger",
+	"api_url": "https://us.battle.net/api/d3/data/item/empyrean-messenger",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spear_003_x1_demonhunter_male.png",
+	"type": "spear",
+	"quality": "legendary",
+	"name": "Empyrean Messenger"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/akanesh-the-herald-of-righteousness",
+	"url_name": "akanesh-the-herald-of-righteousness",
+	"api_url": "https://us.battle.net/api/d3/data/item/akanesh-the-herald-of-righteousness",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_spear_101_x1_demonhunter_male.png",
+	"type": "spear",
+	"quality": "legendary",
+	"name": "Akanesh, the Herald of Righteousness"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/monster-hunter",
+	"url_name": "monster-hunter",
+	"api_url": "https://us.battle.net/api/d3/data/item/monster-hunter",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_017_x1_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "legendary",
+	"name": "Monster Hunter"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/wildwood",
+	"url_name": "wildwood",
+	"api_url": "https://us.battle.net/api/d3/data/item/wildwood",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_002_x1_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "legendary",
+	"name": "Wildwood"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/borns-seething-rage",
+	"url_name": "borns-seething-rage",
+	"api_url": "https://us.battle.net/api/d3/data/item/borns-seething-rage",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_018_1xx_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "set",
+	"name": "Born's Searing Spite"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/doombringer",
+	"url_name": "doombringer",
+	"api_url": "https://us.battle.net/api/d3/data/item/doombringer",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_014_x1_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "legendary",
+	"name": "Doombringer"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-ancient-bonesaber-of-zumakalis",
+	"url_name": "the-ancient-bonesaber-of-zumakalis",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-ancient-bonesaber-of-zumakalis",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_003_x1_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "legendary",
+	"name": "The Ancient Bonesaber of Zumakalis"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/exarian",
+	"url_name": "exarian",
+	"api_url": "https://us.battle.net/api/d3/data/item/exarian",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_102_x1_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "legendary",
+	"name": "Exarian"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/fulminator",
+	"url_name": "fulminator",
+	"api_url": "https://us.battle.net/api/d3/data/item/fulminator",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_sword_1h_104_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "legendary",
+	"name": "Fulminator"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/gift-of-silaria",
+	"url_name": "gift-of-silaria",
+	"api_url": "https://us.battle.net/api/d3/data/item/gift-of-silaria",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_103_x1_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "legendary",
+	"name": "Gift of Silaria"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/rimeheart",
+	"url_name": "rimeheart",
+	"api_url": "https://us.battle.net/api/d3/data/item/rimeheart",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_109_x1_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "legendary",
+	"name": "Rimeheart"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/thunderfury-blessed-blade-of-the-windseeker",
+	"url_name": "thunderfury-blessed-blade-of-the-windseeker",
+	"api_url": "https://us.battle.net/api/d3/data/item/thunderfury-blessed-blade-of-the-windseeker",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_101_x1_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "legendary",
+	"name": "Thunderfury, Blessed Blade of the Windseeker"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/sever",
+	"url_name": "sever",
+	"api_url": "https://us.battle.net/api/d3/data/item/sever",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_007_x1_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "legendary",
+	"name": "Sever"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/skycutter",
+	"url_name": "skycutter",
+	"api_url": "https://us.battle.net/api/d3/data/item/skycutter",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_004_x1_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "legendary",
+	"name": "Skycutter"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/azurewrath",
+	"url_name": "azurewrath",
+	"api_url": "https://us.battle.net/api/d3/data/item/azurewrath",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_sword_1h_012_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "legendary",
+	"name": "Azurewrath"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/devil-tongue",
+	"url_name": "devil-tongue",
+	"api_url": "https://us.battle.net/api/d3/data/item/devil-tongue",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_011_x1_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "legendary",
+	"name": "Devil Tongue"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/griswolds-masterpiece",
+	"url_name": "griswolds-masterpiece",
+	"api_url": "https://us.battle.net/api/d3/data/item/griswolds-masterpiece",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_019_1xx_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "legendary",
+	"name": "Griswold's Masterpiece"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/deathwish",
+	"url_name": "deathwish",
+	"api_url": "https://us.battle.net/api/d3/data/item/deathwish",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_112_x1_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "legendary",
+	"name": "Deathwish"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/griswolds-perfection",
+	"url_name": "griswolds-perfection",
+	"api_url": "https://us.battle.net/api/d3/data/item/griswolds-perfection",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_019_x1_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "legendary",
+	"name": "Griswold's Perfection"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/ingeom",
+	"url_name": "ingeom",
+	"api_url": "https://us.battle.net/api/d3/data/item/ingeom",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_113_x1_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "legendary",
+	"name": "In-geom"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/shard-of-hate",
+	"url_name": "shard-of-hate",
+	"api_url": "https://us.battle.net/api/d3/data/item/shard-of-hate",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_promo_02_x1_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "legendary",
+	"name": "Shard of Hate"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/sword-of-ill-will",
+	"url_name": "sword-of-ill-will",
+	"api_url": "https://us.battle.net/api/d3/data/item/sword-of-ill-will",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_sword_1h_01_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "legendary",
+	"name": "Sword of Ill Will"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-twisted-sword",
+	"url_name": "the-twisted-sword",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-twisted-sword",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_107_x1_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "legendary",
+	"name": "The Twisted Sword"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/borns-furious-wrath",
+	"url_name": "borns-furious-wrath",
+	"api_url": "https://us.battle.net/api/d3/data/item/borns-furious-wrath",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_018_x1_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "set",
+	"name": "Born's Furious Wrath"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/little-rogue",
+	"url_name": "little-rogue",
+	"api_url": "https://us.battle.net/api/d3/data/item/little-rogue",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_set_03_x1_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "set",
+	"name": "Little Rogue"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-slanderer",
+	"url_name": "the-slanderer",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-slanderer",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_1h_set_02_x1_demonhunter_male.png",
+	"type": "sword-1h",
+	"quality": "set",
+	"name": "The Slanderer"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/deadly-rebirth",
+	"url_name": "deadly-rebirth",
+	"api_url": "https://us.battle.net/api/d3/data/item/deadly-rebirth",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ceremonialdagger_003_x1_demonhunter_male.png",
+	"type": "ceremonial-knife",
+	"quality": "legendary",
+	"name": "Deadly Rebirth"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/umbral-oath",
+	"url_name": "umbral-oath",
+	"api_url": "https://us.battle.net/api/d3/data/item/umbral-oath",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ceremonialdagger_006_1xx_demonhunter_male.png",
+	"type": "ceremonial-knife",
+	"quality": "legendary",
+	"name": "Umbral Oath"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/rhenho-flayer",
+	"url_name": "rhenho-flayer",
+	"api_url": "https://us.battle.net/api/d3/data/item/rhenho-flayer",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ceremonialdagger_102_x1_demonhunter_male.png",
+	"type": "ceremonial-knife",
+	"quality": "legendary",
+	"name": "Rhen'ho Flayer"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/sacred-harvester",
+	"url_name": "sacred-harvester",
+	"api_url": "https://us.battle.net/api/d3/data/item/sacred-harvester",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p1_ceremonialdagger_norm_unique_01_demonhunter_male.png",
+	"type": "ceremonial-knife",
+	"quality": "legendary",
+	"name": "Sacred Harvester"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-dagger-of-darts",
+	"url_name": "the-dagger-of-darts",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-dagger-of-darts",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p1_ceremonialdagger_norm_unique_02_demonhunter_male.png",
+	"type": "ceremonial-knife",
+	"quality": "legendary",
+	"name": "The Dagger of Darts"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/last-breath",
+	"url_name": "last-breath",
+	"api_url": "https://us.battle.net/api/d3/data/item/last-breath",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_ceremonialdagger_008_demonhunter_male.png",
+	"type": "ceremonial-knife",
+	"quality": "legendary",
+	"name": "Last Breath"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-spider-queens-grasp",
+	"url_name": "the-spider-queens-grasp",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-spider-queens-grasp",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ceremonialdagger_004_x1_demonhunter_male.png",
+	"type": "ceremonial-knife",
+	"quality": "legendary",
+	"name": "The Spider Queen's Grasp"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/starmetal-kukri",
+	"url_name": "starmetal-kukri",
+	"api_url": "https://us.battle.net/api/d3/data/item/starmetal-kukri",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ceremonialdagger_101_x1_demonhunter_male.png",
+	"type": "ceremonial-knife",
+	"quality": "legendary",
+	"name": "Starmetal Kukri"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/anessazi-edge",
+	"url_name": "anessazi-edge",
+	"api_url": "https://us.battle.net/api/d3/data/item/anessazi-edge",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ceremonialdagger_001_x1_demonhunter_male.png",
+	"type": "ceremonial-knife",
+	"quality": "legendary",
+	"name": "Anessazi Edge"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/voos-juicer",
+	"url_name": "voos-juicer",
+	"api_url": "https://us.battle.net/api/d3/data/item/voos-juicer",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_dagger_002_demonhunter_male.png",
+	"type": "ceremonial-knife",
+	"quality": "legendary",
+	"name": "Voo's Juicer"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-gidbinn",
+	"url_name": "the-gidbinn",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-gidbinn",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ceremonialdagger_002_x1_demonhunter_male.png",
+	"type": "ceremonial-knife",
+	"quality": "legendary",
+	"name": "The Gidbinn"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/manajumas-carving-knife",
+	"url_name": "manajumas-carving-knife",
+	"api_url": "https://us.battle.net/api/d3/data/item/manajumas-carving-knife",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ceremonialdagger_009_x1_demonhunter_male.png",
+	"type": "ceremonial-knife",
+	"quality": "set",
+	"name": "Manajuma's Carving Knife"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-sacrifice",
+	"url_name": "hallowed-sacrifice",
+	"api_url": "https://us.battle.net/api/d3/data/item/hallowed-sacrifice",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ceremonialdagger_011_1xx_demonhunter_male.png",
+	"type": "ceremonial-knife",
+	"quality": "set",
+	"name": "Hallowed Salvation"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/living-umbral-oath",
+	"url_name": "living-umbral-oath",
+	"api_url": "https://us.battle.net/api/d3/data/item/living-umbral-oath",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ceremonialdagger_006_x1_demonhunter_male.png",
+	"type": "ceremonial-knife",
+	"quality": "legendary",
+	"name": "Living Umbral Oath"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-sufferance",
+	"url_name": "hallowed-sufferance",
+	"api_url": "https://us.battle.net/api/d3/data/item/hallowed-sufferance",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_ceremonialdagger_011_x1_demonhunter_male.png",
+	"type": "ceremonial-knife",
+	"quality": "set",
+	"name": "Hallowed Sufferance"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/fleshrake",
+	"url_name": "fleshrake",
+	"api_url": "https://us.battle.net/api/d3/data/item/fleshrake",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_007_x1_demonhunter_male.png",
+	"type": "fist-weapon",
+	"quality": "legendary",
+	"name": "Fleshrake"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/rabid-strike",
+	"url_name": "rabid-strike",
+	"api_url": "https://us.battle.net/api/d3/data/item/rabid-strike",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_003_x1_demonhunter_male.png",
+	"type": "fist-weapon",
+	"quality": "legendary",
+	"name": "Rabid Strike"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/scarbringer",
+	"url_name": "scarbringer",
+	"api_url": "https://us.battle.net/api/d3/data/item/scarbringer",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_013_x1_demonhunter_male.png",
+	"type": "fist-weapon",
+	"quality": "legendary",
+	"name": "Scarbringer"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/sledge-fist",
+	"url_name": "sledge-fist",
+	"api_url": "https://us.battle.net/api/d3/data/item/sledge-fist",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_012_x1_demonhunter_male.png",
+	"type": "fist-weapon",
+	"quality": "legendary",
+	"name": "Sledge Fist"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/jawbreaker",
+	"url_name": "jawbreaker",
+	"api_url": "https://us.battle.net/api/d3/data/item/jawbreaker",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_101_x1_demonhunter_male.png",
+	"type": "fist-weapon",
+	"quality": "legendary",
+	"name": "Jawbreaker"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/logans-claw",
+	"url_name": "logans-claw",
+	"api_url": "https://us.battle.net/api/d3/data/item/logans-claw",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_005_x1_demonhunter_male.png",
+	"type": "fist-weapon",
+	"quality": "legendary",
+	"name": "Logan's Claw"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demon-hand",
+	"url_name": "demon-hand",
+	"api_url": "https://us.battle.net/api/d3/data/item/demon-hand",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_004_1xx_demonhunter_male.png",
+	"type": "fist-weapon",
+	"quality": "legendary",
+	"name": "Demon Hand"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/crystal-fist",
+	"url_name": "crystal-fist",
+	"api_url": "https://us.battle.net/api/d3/data/item/crystal-fist",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_008_x1_demonhunter_male.png",
+	"type": "fist-weapon",
+	"quality": "legendary",
+	"name": "Crystal Fist"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-fist-of-azturrasq",
+	"url_name": "the-fist-of-azturrasq",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-fist-of-azturrasq",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_fist_009_x1_demonhunter_male.png",
+	"type": "fist-weapon",
+	"quality": "legendary",
+	"name": "The Fist of Az'Turrasq"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/won-khim-lau",
+	"url_name": "won-khim-lau",
+	"api_url": "https://us.battle.net/api/d3/data/item/won-khim-lau",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_006_x1_demonhunter_male.png",
+	"type": "fist-weapon",
+	"quality": "legendary",
+	"name": "Won Khim Lau"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/shenlongs-fist-of-legend",
+	"url_name": "shenlongs-fist-of-legend",
+	"api_url": "https://us.battle.net/api/d3/data/item/shenlongs-fist-of-legend",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_011_x1_demonhunter_male.png",
+	"type": "fist-weapon",
+	"quality": "set",
+	"name": "Shenlong's Fist of Legend"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/shenlongs-relentless-assault",
+	"url_name": "shenlongs-relentless-assault",
+	"api_url": "https://us.battle.net/api/d3/data/item/shenlongs-relentless-assault",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_010_x1_demonhunter_male.png",
+	"type": "fist-weapon",
+	"quality": "set",
+	"name": "Shenlong's Relentless Assault"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-touch",
+	"url_name": "hallowed-touch",
+	"api_url": "https://us.battle.net/api/d3/data/item/hallowed-touch",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_015_1xx_demonhunter_male.png",
+	"type": "fist-weapon",
+	"quality": "set",
+	"name": "Hallowed Hand"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/demon-claw",
+	"url_name": "demon-claw",
+	"api_url": "https://us.battle.net/api/d3/data/item/demon-claw",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_004_x1_demonhunter_male.png",
+	"type": "fist-weapon",
+	"quality": "legendary",
+	"name": "Demon Claw"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/kyoshiros-blade",
+	"url_name": "kyoshiros-blade",
+	"api_url": "https://us.battle.net/api/d3/data/item/kyoshiros-blade",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_fist_102_demonhunter_male.png",
+	"type": "fist-weapon",
+	"quality": "legendary",
+	"name": "Kyoshiro's Blade"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/lions-claw",
+	"url_name": "lions-claw",
+	"api_url": "https://us.battle.net/api/d3/data/item/lions-claw",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p1_fistweapon_norm_unique_01_demonhunter_male.png",
+	"type": "fist-weapon",
+	"quality": "legendary",
+	"name": "Lion’s Claw"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/vengeful-wind",
+	"url_name": "vengeful-wind",
+	"api_url": "https://us.battle.net/api/d3/data/item/vengeful-wind",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_fistweapon_norm_unique_02_demonhunter_male.png",
+	"type": "fist-weapon",
+	"quality": "legendary",
+	"name": "Vengeful Wind"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-hold",
+	"url_name": "hallowed-hold",
+	"api_url": "https://us.battle.net/api/d3/data/item/hallowed-hold",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_fist_015_x1_demonhunter_male.png",
+	"type": "fist-weapon",
+	"quality": "set",
+	"name": "Hallowed Hold"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/johannas-argument",
+	"url_name": "johannas-argument",
+	"api_url": "https://us.battle.net/api/d3/data/item/johannas-argument",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p1_flail1h_norm_unique_01_demonhunter_male.png",
+	"type": "flail-1h",
+	"quality": "legendary",
+	"name": "Johanna's Argument"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/darklight",
+	"url_name": "darklight",
+	"api_url": "https://us.battle.net/api/d3/data/item/darklight",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_flail_1h_106_x1_demonhunter_male.png",
+	"type": "flail-1h",
+	"quality": "legendary",
+	"name": "Darklight"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/gyrfalcons-foote",
+	"url_name": "gyrfalcons-foote",
+	"api_url": "https://us.battle.net/api/d3/data/item/gyrfalcons-foote",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_flail_1h_105_x1_demonhunter_male.png",
+	"type": "flail-1h",
+	"quality": "legendary",
+	"name": "Gyrfalcon's Foote"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/inviolable-faith",
+	"url_name": "inviolable-faith",
+	"api_url": "https://us.battle.net/api/d3/data/item/inviolable-faith",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_flail_1h_107_x1_demonhunter_male.png",
+	"type": "flail-1h",
+	"quality": "legendary",
+	"name": "Inviolable Faith"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/justinians-mercy",
+	"url_name": "justinians-mercy",
+	"api_url": "https://us.battle.net/api/d3/data/item/justinians-mercy",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_flail_1h_102_x1_demonhunter_male.png",
+	"type": "flail-1h",
+	"quality": "legendary",
+	"name": "Justinian's Mercy"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/kassars-retribution",
+	"url_name": "kassars-retribution",
+	"api_url": "https://us.battle.net/api/d3/data/item/kassars-retribution",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_flail_1h_104_x1_demonhunter_male.png",
+	"type": "flail-1h",
+	"quality": "legendary",
+	"name": "Kassar's Retribution"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/swiftmount",
+	"url_name": "swiftmount",
+	"api_url": "https://us.battle.net/api/d3/data/item/swiftmount",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_flail_1h_103_x1_demonhunter_male.png",
+	"type": "flail-1h",
+	"quality": "legendary",
+	"name": "Swiftmount"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/golden-scourge",
+	"url_name": "golden-scourge",
+	"api_url": "https://us.battle.net/api/d3/data/item/golden-scourge",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_flail_1h_101_x1_demonhunter_male.png",
+	"type": "flail-1h",
+	"quality": "legendary",
+	"name": "Golden Scourge"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/fjord-cutter",
+	"url_name": "fjord-cutter",
+	"api_url": "https://us.battle.net/api/d3/data/item/fjord-cutter",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_mighty_1h_006_demonhunter_male.png",
+	"type": "mighty-weapon-1h",
+	"quality": "legendary",
+	"name": "Fjord Cutter"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/ambos-pride",
+	"url_name": "ambos-pride",
+	"api_url": "https://us.battle.net/api/d3/data/item/ambos-pride",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_1h_012_x1_demonhunter_male.png",
+	"type": "mighty-weapon-1h",
+	"quality": "legendary",
+	"name": "Ambo's Pride"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/harvest-moon",
+	"url_name": "harvest-moon",
+	"api_url": "https://us.battle.net/api/d3/data/item/harvest-moon",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_1h_001_1xx_demonhunter_male.png",
+	"type": "mighty-weapon-1h",
+	"quality": "legendary",
+	"name": "Harvest Moon"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/blade-of-the-warlord",
+	"url_name": "blade-of-the-warlord",
+	"api_url": "https://us.battle.net/api/d3/data/item/blade-of-the-warlord",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_mighty_1h_005_demonhunter_male.png",
+	"type": "mighty-weapon-1h",
+	"quality": "legendary",
+	"name": "Blade of the Warlord"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/bulkathoss-solemn-vow",
+	"url_name": "bulkathoss-solemn-vow",
+	"api_url": "https://us.battle.net/api/d3/data/item/bulkathoss-solemn-vow",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_1h_010_x1_demonhunter_male.png",
+	"type": "mighty-weapon-1h",
+	"quality": "set",
+	"name": "Bul-Kathos's Solemn Vow"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/bulkathoss-warrior-blood",
+	"url_name": "bulkathoss-warrior-blood",
+	"api_url": "https://us.battle.net/api/d3/data/item/bulkathoss-warrior-blood",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_1h_011_x1_demonhunter_male.png",
+	"type": "mighty-weapon-1h",
+	"quality": "set",
+	"name": "Bul-Kathos's Warrior Blood"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-destroyer",
+	"url_name": "hallowed-destroyer",
+	"api_url": "https://us.battle.net/api/d3/data/item/hallowed-destroyer",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_1h_015_1xx_demonhunter_male.png",
+	"type": "mighty-weapon-1h",
+	"quality": "set",
+	"name": "Hallowed Reckoning"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/dishonored-legacy",
+	"url_name": "dishonored-legacy",
+	"api_url": "https://us.battle.net/api/d3/data/item/dishonored-legacy",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_1h_103_x1_demonhunter_male.png",
+	"type": "mighty-weapon-1h",
+	"quality": "legendary",
+	"name": "Dishonored Legacy"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/nights-reaping",
+	"url_name": "nights-reaping",
+	"api_url": "https://us.battle.net/api/d3/data/item/nights-reaping",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_1h_001_x1_demonhunter_male.png",
+	"type": "mighty-weapon-1h",
+	"quality": "legendary",
+	"name": "Night's Reaping"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/oathkeeper",
+	"url_name": "oathkeeper",
+	"api_url": "https://us.battle.net/api/d3/data/item/oathkeeper",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_mighty_1h_104_demonhunter_male.png",
+	"type": "mighty-weapon-1h",
+	"quality": "legendary",
+	"name": "Oathkeeper"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/remorseless",
+	"url_name": "remorseless",
+	"api_url": "https://us.battle.net/api/d3/data/item/remorseless",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_1h_102_x1_demonhunter_male.png",
+	"type": "mighty-weapon-1h",
+	"quality": "legendary",
+	"name": "Remorseless"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-nemesis",
+	"url_name": "hallowed-nemesis",
+	"api_url": "https://us.battle.net/api/d3/data/item/hallowed-nemesis",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_1h_015_x1_demonhunter_male.png",
+	"type": "mighty-weapon-1h",
+	"quality": "set",
+	"name": "Hallowed Nemesis"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-executioner",
+	"url_name": "the-executioner",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-executioner",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_2h_003_x1_demonhunter_male.png",
+	"type": "axe-2h",
+	"quality": "legendary",
+	"name": "The Executioner"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/burst-of-wrath",
+	"url_name": "burst-of-wrath",
+	"api_url": "https://us.battle.net/api/d3/data/item/burst-of-wrath",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_2h_103_x1_demonhunter_male.png",
+	"type": "axe-2h",
+	"quality": "legendary",
+	"name": "Burst of Wrath"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/butchers-carver",
+	"url_name": "butchers-carver",
+	"api_url": "https://us.battle.net/api/d3/data/item/butchers-carver",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_2h_001_x1_demonhunter_male.png",
+	"type": "axe-2h",
+	"quality": "legendary",
+	"name": "Butcher's Carver"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/messerschmidts-reaver",
+	"url_name": "messerschmidts-reaver",
+	"api_url": "https://us.battle.net/api/d3/data/item/messerschmidts-reaver",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_2h_011_x1_demonhunter_male.png",
+	"type": "axe-2h",
+	"quality": "legendary",
+	"name": "Messerschmidt's Reaver"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/skorn",
+	"url_name": "skorn",
+	"api_url": "https://us.battle.net/api/d3/data/item/skorn",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_2h_009_x1_demonhunter_male.png",
+	"type": "axe-2h",
+	"quality": "legendary",
+	"name": "Skorn"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/fire-brand",
+	"url_name": "fire-brand",
+	"api_url": "https://us.battle.net/api/d3/data/item/fire-brand",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_2h_010_1xx_demonhunter_male.png",
+	"type": "axe-2h",
+	"quality": "legendary",
+	"name": "Fire Brand"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/cinder-switch",
+	"url_name": "cinder-switch",
+	"api_url": "https://us.battle.net/api/d3/data/item/cinder-switch",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_axe_2h_010_x1_demonhunter_male.png",
+	"type": "axe-2h",
+	"quality": "legendary",
+	"name": "Cinder Switch"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/arthefs-spark-of-life",
+	"url_name": "arthefs-spark-of-life",
+	"api_url": "https://us.battle.net/api/d3/data/item/arthefs-spark-of-life",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_2h_003_x1_demonhunter_male.png",
+	"type": "mace-2h",
+	"quality": "legendary",
+	"name": "Arthef's Spark of Life"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/crushbane",
+	"url_name": "crushbane",
+	"api_url": "https://us.battle.net/api/d3/data/item/crushbane",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_2h_001_x1_demonhunter_male.png",
+	"type": "mace-2h",
+	"quality": "legendary",
+	"name": "Crushbane"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/soulsmasher",
+	"url_name": "soulsmasher",
+	"api_url": "https://us.battle.net/api/d3/data/item/soulsmasher",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_2h_104_x1_demonhunter_male.png",
+	"type": "mace-2h",
+	"quality": "legendary",
+	"name": "Soulsmasher"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/skywarden",
+	"url_name": "skywarden",
+	"api_url": "https://us.battle.net/api/d3/data/item/skywarden",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_2h_010_x1_demonhunter_male.png",
+	"type": "mace-2h",
+	"quality": "legendary",
+	"name": "Skywarden"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/wrath-of-the-bone-king",
+	"url_name": "wrath-of-the-bone-king",
+	"api_url": "https://us.battle.net/api/d3/data/item/wrath-of-the-bone-king",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_2h_012_p1_demonhunter_male.png",
+	"type": "mace-2h",
+	"quality": "legendary",
+	"name": "Wrath of the Bone King"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-furnace",
+	"url_name": "the-furnace",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-furnace",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_2h_103_x1_demonhunter_male.png",
+	"type": "mace-2h",
+	"quality": "legendary",
+	"name": "The Furnace"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/cataclysm",
+	"url_name": "cataclysm",
+	"api_url": "https://us.battle.net/api/d3/data/item/cataclysm",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_2h_006_1xx_demonhunter_male.png",
+	"type": "mace-2h",
+	"quality": "legendary",
+	"name": "Cataclysm"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/schaefers-hammer",
+	"url_name": "schaefers-hammer",
+	"api_url": "https://us.battle.net/api/d3/data/item/schaefers-hammer",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_2h_009_p2_demonhunter_male.png",
+	"type": "mace-2h",
+	"quality": "legendary",
+	"name": "Schaefer's Hammer"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/sledge-of-athskeleng",
+	"url_name": "sledge-of-athskeleng",
+	"api_url": "https://us.battle.net/api/d3/data/item/sledge-of-athskeleng",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_2h_002_x1_demonhunter_male.png",
+	"type": "mace-2h",
+	"quality": "legendary",
+	"name": "Sledge of Athskeleng"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/sunder",
+	"url_name": "sunder",
+	"api_url": "https://us.battle.net/api/d3/data/item/sunder",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mace_2h_006_x1_demonhunter_male.png",
+	"type": "mace-2h",
+	"quality": "legendary",
+	"name": "Sunder"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/pledge-of-caldeum",
+	"url_name": "pledge-of-caldeum",
+	"api_url": "https://us.battle.net/api/d3/data/item/pledge-of-caldeum",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_polearm_002_x1_demonhunter_male.png",
+	"type": "polearm",
+	"quality": "legendary",
+	"name": "Pledge of Caldeum"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/standoff",
+	"url_name": "standoff",
+	"api_url": "https://us.battle.net/api/d3/data/item/standoff",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_polearm_01_demonhunter_male.png",
+	"type": "polearm",
+	"quality": "legendary",
+	"name": "Standoff"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/bovine-bardiche",
+	"url_name": "bovine-bardiche",
+	"api_url": "https://us.battle.net/api/d3/data/item/bovine-bardiche",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_polearm_101_x1_demonhunter_male.png",
+	"type": "polearm",
+	"quality": "legendary",
+	"name": "Bovine Bardiche"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/heart-slaughter",
+	"url_name": "heart-slaughter",
+	"api_url": "https://us.battle.net/api/d3/data/item/heart-slaughter",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_polearm_003_p1_demonhunter_male.png",
+	"type": "polearm",
+	"quality": "legendary",
+	"name": "Heart Slaughter"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/vigilance",
+	"url_name": "vigilance",
+	"api_url": "https://us.battle.net/api/d3/data/item/vigilance",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_polearm_001_x1_demonhunter_male.png",
+	"type": "polearm",
+	"quality": "legendary",
+	"name": "Vigilance"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/staff-of-chiroptera",
+	"url_name": "staff-of-chiroptera",
+	"api_url": "https://us.battle.net/api/d3/data/item/staff-of-chiroptera",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_staff_001_demonhunter_male.png",
+	"type": "staff",
+	"quality": "legendary",
+	"name": "Staff of Chiroptera"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-broken-staff",
+	"url_name": "the-broken-staff",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-broken-staff",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_staff_001_x1_demonhunter_male.png",
+	"type": "staff",
+	"quality": "legendary",
+	"name": "The Broken Staff"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/ahavarion-spear-of-lycander",
+	"url_name": "ahavarion-spear-of-lycander",
+	"api_url": "https://us.battle.net/api/d3/data/item/ahavarion-spear-of-lycander",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_staff_101_x1_demonhunter_male.png",
+	"type": "staff",
+	"quality": "legendary",
+	"name": "Ahavarion, Spear of Lycander"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/suwong-diviner",
+	"url_name": "suwong-diviner",
+	"api_url": "https://us.battle.net/api/d3/data/item/suwong-diviner",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_staff_104_x1_demonhunter_male.png",
+	"type": "staff",
+	"quality": "legendary",
+	"name": "SuWong Diviner"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-smoldering-core",
+	"url_name": "the-smoldering-core",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-smoldering-core",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_staff_103_x1_demonhunter_male.png",
+	"type": "staff",
+	"quality": "legendary",
+	"name": "The Smoldering Core"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/valtheks-rebuke",
+	"url_name": "valtheks-rebuke",
+	"api_url": "https://us.battle.net/api/d3/data/item/valtheks-rebuke",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_staff_102_x1_demonhunter_male.png",
+	"type": "staff",
+	"quality": "legendary",
+	"name": "Valthek's Rebuke"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/the-magi",
+	"url_name": "the-magi",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-magi",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_staff_002_1xx_demonhunter_male.png",
+	"type": "staff",
+	"quality": "legendary",
+	"name": "The Magi"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/maloths-focus",
+	"url_name": "maloths-focus",
+	"api_url": "https://us.battle.net/api/d3/data/item/maloths-focus",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_staff_006_x1_demonhunter_male.png",
+	"type": "staff",
+	"quality": "legendary",
+	"name": "Maloth's Focus"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/wormwood",
+	"url_name": "wormwood",
+	"api_url": "https://us.battle.net/api/d3/data/item/wormwood",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_staff_003_demonhunter_male.png",
+	"type": "staff",
+	"quality": "legendary",
+	"name": "Wormwood"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-grand-vizier",
+	"url_name": "the-grand-vizier",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-grand-vizier",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_staff_009_p1_demonhunter_male.png",
+	"type": "staff",
+	"quality": "legendary",
+	"name": "The Grand Vizier"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-tormentor",
+	"url_name": "the-tormentor",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-tormentor",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_staff_007_x1_demonhunter_male.png",
+	"type": "staff",
+	"quality": "legendary",
+	"name": "The Tormentor"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/mark-of-the-magi",
+	"url_name": "mark-of-the-magi",
+	"api_url": "https://us.battle.net/api/d3/data/item/mark-of-the-magi",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_staff_002_x1_demonhunter_male.png",
+	"type": "staff",
+	"quality": "legendary",
+	"name": "Mark of The Magi"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/faithful-memory",
+	"url_name": "faithful-memory",
+	"api_url": "https://us.battle.net/api/d3/data/item/faithful-memory",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_012_x1_demonhunter_male.png",
+	"type": "sword-2h",
+	"quality": "legendary",
+	"name": "Faithful Memory"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-zweihander",
+	"url_name": "the-zweihander",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-zweihander",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_002_x1_demonhunter_male.png",
+	"type": "sword-2h",
+	"quality": "legendary",
+	"name": "The Zweihander"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/blackguard",
+	"url_name": "blackguard",
+	"api_url": "https://us.battle.net/api/d3/data/item/blackguard",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_011_x1_demonhunter_male.png",
+	"type": "sword-2h",
+	"quality": "legendary",
+	"name": "Blackguard"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/scourge",
+	"url_name": "scourge",
+	"api_url": "https://us.battle.net/api/d3/data/item/scourge",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_004_x1_demonhunter_male.png",
+	"type": "sword-2h",
+	"quality": "legendary",
+	"name": "Scourge"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/stalgards-decimator",
+	"url_name": "stalgards-decimator",
+	"api_url": "https://us.battle.net/api/d3/data/item/stalgards-decimator",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_101_x1_demonhunter_male.png",
+	"type": "sword-2h",
+	"quality": "legendary",
+	"name": "Stalgard's Decimator"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/blade-of-prophecy",
+	"url_name": "blade-of-prophecy",
+	"api_url": "https://us.battle.net/api/d3/data/item/blade-of-prophecy",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_007_x1_demonhunter_male.png",
+	"type": "sword-2h",
+	"quality": "legendary",
+	"name": "Blade of Prophecy"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-sultan-of-blinding-sand",
+	"url_name": "the-sultan-of-blinding-sand",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-sultan-of-blinding-sand",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_008_x1_demonhunter_male.png",
+	"type": "sword-2h",
+	"quality": "legendary",
+	"name": "The Sultan of Blinding Sand"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/maximus",
+	"url_name": "maximus",
+	"api_url": "https://us.battle.net/api/d3/data/item/maximus",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_010_x1_demonhunter_male.png",
+	"type": "sword-2h",
+	"quality": "legendary",
+	"name": "Maximus"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-grandfather",
+	"url_name": "the-grandfather",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-grandfather",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_001_x1_demonhunter_male.png",
+	"type": "sword-2h",
+	"quality": "legendary",
+	"name": "The Grandfather"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/warmonger",
+	"url_name": "warmonger",
+	"api_url": "https://us.battle.net/api/d3/data/item/warmonger",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_003_x1_demonhunter_male.png",
+	"type": "sword-2h",
+	"quality": "legendary",
+	"name": "Warmonger"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/cams-rebuttal",
+	"url_name": "cams-rebuttal",
+	"api_url": "https://us.battle.net/api/d3/data/item/cams-rebuttal",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_102_x1_demonhunter_male.png",
+	"type": "sword-2h",
+	"quality": "legendary",
+	"name": "Cam's Rebuttal"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/blood-brother",
+	"url_name": "blood-brother",
+	"api_url": "https://us.battle.net/api/d3/data/item/blood-brother",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_103_x1_demonhunter_male.png",
+	"type": "sword-2h",
+	"quality": "legendary",
+	"name": "Blood Brother"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/corrupted-ashbringer",
+	"url_name": "corrupted-ashbringer",
+	"api_url": "https://us.battle.net/api/d3/data/item/corrupted-ashbringer",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_sword_2h_104_x1_demonhunter_male.png",
+	"type": "sword-2h",
+	"quality": "legendary",
+	"name": "Corrupted Ashbringer"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/balance",
+	"url_name": "balance",
+	"api_url": "https://us.battle.net/api/d3/data/item/balance",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_combatstaff_2h_001_demonhunter_male.png",
+	"type": "daibo",
+	"quality": "legendary",
+	"name": "Balance"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/lai-yuis-taiji",
+	"url_name": "lai-yuis-taiji",
+	"api_url": "https://us.battle.net/api/d3/data/item/lai-yuis-taiji",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_combatstaff_2h_008_1xx_demonhunter_male.png",
+	"type": "daibo",
+	"quality": "legendary",
+	"name": "Lai Yui's Taiji"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-flow-of-eternity",
+	"url_name": "the-flow-of-eternity",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-flow-of-eternity",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_combatstaff_2h_005_x1_demonhunter_male.png",
+	"type": "daibo",
+	"quality": "legendary",
+	"name": "The Flow of Eternity"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-paddle",
+	"url_name": "the-paddle",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-paddle",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_combatstaff_2h_007_x1_demonhunter_male.png",
+	"type": "daibo",
+	"quality": "legendary",
+	"name": "The Paddle"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/staff-of-kyro",
+	"url_name": "staff-of-kyro",
+	"api_url": "https://us.battle.net/api/d3/data/item/staff-of-kyro",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_combatstaff_2h_101_x1_demonhunter_male.png",
+	"type": "daibo",
+	"quality": "legendary",
+	"name": "Staff of Kyro"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/warstaff-of-general-quang",
+	"url_name": "warstaff-of-general-quang",
+	"api_url": "https://us.battle.net/api/d3/data/item/warstaff-of-general-quang",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_combatstaff_2h_102_x1_demonhunter_male.png",
+	"type": "daibo",
+	"quality": "legendary",
+	"name": "Warstaff of General Quang"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/incense-torch-of-the-grand-temple",
+	"url_name": "incense-torch-of-the-grand-temple",
+	"api_url": "https://us.battle.net/api/d3/data/item/incense-torch-of-the-grand-temple",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_combatstaff_2h_003_x1_demonhunter_male.png",
+	"type": "daibo",
+	"quality": "legendary",
+	"name": "Incense Torch of the Grand Temple"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/flying-dragon",
+	"url_name": "flying-dragon",
+	"api_url": "https://us.battle.net/api/d3/data/item/flying-dragon",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_combatstaff_2h_009_x1_demonhunter_male.png",
+	"type": "daibo",
+	"quality": "legendary",
+	"name": "Flying Dragon"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/innas-reach",
+	"url_name": "innas-reach",
+	"api_url": "https://us.battle.net/api/d3/data/item/innas-reach",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_combatstaff_2h_001_x1_demonhunter_male.png",
+	"type": "daibo",
+	"quality": "set",
+	"name": "Inna's Reach"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/rozpedins-staff",
+	"url_name": "rozpedins-staff",
+	"api_url": "https://us.battle.net/api/d3/data/item/rozpedins-staff",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_combatstaff_2h_004_1xx_demonhunter_male.png",
+	"type": "daibo",
+	"quality": "legendary",
+	"name": "Rozpedin's Staff"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/lai-yuis-persuader",
+	"url_name": "lai-yuis-persuader",
+	"api_url": "https://us.battle.net/api/d3/data/item/lai-yuis-persuader",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_combatstaff_2h_008_x1_demonhunter_male.png",
+	"type": "daibo",
+	"quality": "legendary",
+	"name": "Lai Yui's Persuader"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/rozpedins-force",
+	"url_name": "rozpedins-force",
+	"api_url": "https://us.battle.net/api/d3/data/item/rozpedins-force",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_combatstaff_2h_004_x1_demonhunter_male.png",
+	"type": "daibo",
+	"quality": "legendary",
+	"name": "Rozpedin's Force"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/akkhans-addendum",
+	"url_name": "akkhans-addendum",
+	"api_url": "https://us.battle.net/api/d3/data/item/akkhans-addendum",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_flail_2h_001_demonhunter_male.png",
+	"type": "flail-2h",
+	"quality": "legendary",
+	"name": "Akkhan's Addendum"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/baleful-remnant",
+	"url_name": "baleful-remnant",
+	"api_url": "https://us.battle.net/api/d3/data/item/baleful-remnant",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_flail_2h_102_x1_demonhunter_male.png",
+	"type": "flail-2h",
+	"quality": "legendary",
+	"name": "Baleful Remnant"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/fate-of-the-fell",
+	"url_name": "fate-of-the-fell",
+	"api_url": "https://us.battle.net/api/d3/data/item/fate-of-the-fell",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_flail_2h_103_x1_demonhunter_male.png",
+	"type": "flail-2h",
+	"quality": "legendary",
+	"name": "Fate of the Fell"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/golden-flense",
+	"url_name": "golden-flense",
+	"api_url": "https://us.battle.net/api/d3/data/item/golden-flense",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_flail_2h_104_demonhunter_male.png",
+	"type": "flail-2h",
+	"quality": "legendary",
+	"name": "Golden Flense"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-mortal-drama",
+	"url_name": "the-mortal-drama",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-mortal-drama",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_flail_2h_101_x1_demonhunter_male.png",
+	"type": "flail-2h",
+	"quality": "legendary",
+	"name": "The Mortal Drama"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/akkhans-leniency",
+	"url_name": "akkhans-leniency",
+	"api_url": "https://us.battle.net/api/d3/data/item/akkhans-leniency",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_flail2h_norm_unique_01_demonhunter_male.png",
+	"type": "flail-2h",
+	"quality": "legendary",
+	"name": "Akkhan’s Leniency"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/flail-of-the-charge",
+	"url_name": "flail-of-the-charge",
+	"api_url": "https://us.battle.net/api/d3/data/item/flail-of-the-charge",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_flail_2h_set_01_x1_demonhunter_male.png",
+	"type": "flail-2h",
+	"quality": "set",
+	"name": "Flail of the Charge"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/unending-war",
+	"url_name": "unending-war",
+	"api_url": "https://us.battle.net/api/d3/data/item/unending-war",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_2h_012_1xx_demonhunter_male.png",
+	"type": "mighty-weapon-2h",
+	"quality": "legendary",
+	"name": "Unending War"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/bastions-revered",
+	"url_name": "bastions-revered",
+	"api_url": "https://us.battle.net/api/d3/data/item/bastions-revered",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_2h_004_p1_demonhunter_male.png",
+	"type": "mighty-weapon-2h",
+	"quality": "legendary",
+	"name": "Bastion's Revered"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/fury-of-the-vanished-peak",
+	"url_name": "fury-of-the-vanished-peak",
+	"api_url": "https://us.battle.net/api/d3/data/item/fury-of-the-vanished-peak",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_mighty_2h_006_demonhunter_male.png",
+	"type": "mighty-weapon-2h",
+	"quality": "legendary",
+	"name": "Fury of the Vanished Peak"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/madawcs-sorrow",
+	"url_name": "madawcs-sorrow",
+	"api_url": "https://us.battle.net/api/d3/data/item/madawcs-sorrow",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_2h_101_x1_demonhunter_male.png",
+	"type": "mighty-weapon-2h",
+	"quality": "legendary",
+	"name": "Madawc's Sorrow"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-gavel-of-judgment",
+	"url_name": "the-gavel-of-judgment",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-gavel-of-judgment",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_mighty_2h_001_demonhunter_male.png",
+	"type": "mighty-weapon-2h",
+	"quality": "legendary",
+	"name": "The Gavel of Judgment"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/immortal-kings-boulder-breaker",
+	"url_name": "immortal-kings-boulder-breaker",
+	"api_url": "https://us.battle.net/api/d3/data/item/immortal-kings-boulder-breaker",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_2h_010_x1_demonhunter_male.png",
+	"type": "mighty-weapon-2h",
+	"quality": "set",
+	"name": "Immortal King's Boulder Breaker"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/blade-of-the-tribes",
+	"url_name": "blade-of-the-tribes",
+	"api_url": "https://us.battle.net/api/d3/data/item/blade-of-the-tribes",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_mighty_2h_101_demonhunter_male.png",
+	"type": "mighty-weapon-2h",
+	"quality": "legendary",
+	"name": "Blade of the Tribes"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/war-of-the-dead",
+	"url_name": "war-of-the-dead",
+	"api_url": "https://us.battle.net/api/d3/data/item/war-of-the-dead",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_mighty_2h_012_x1_demonhunter_male.png",
+	"type": "mighty-weapon-2h",
+	"quality": "legendary",
+	"name": "War of the Dead"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/uskang",
+	"url_name": "uskang",
+	"api_url": "https://us.battle.net/api/d3/data/item/uskang",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_005_p1_demonhunter_male.png",
+	"type": "bow",
+	"quality": "legendary",
+	"name": "Uskang"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/longshot",
+	"url_name": "longshot",
+	"api_url": "https://us.battle.net/api/d3/data/item/longshot",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_007_1xx_demonhunter_male.png",
+	"type": "bow",
+	"quality": "legendary",
+	"name": "Longshot"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/etrayu",
+	"url_name": "etrayu",
+	"api_url": "https://us.battle.net/api/d3/data/item/etrayu",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_001_p1_demonhunter_male.png",
+	"type": "bow",
+	"quality": "legendary",
+	"name": "Etrayu"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-ravens-wing",
+	"url_name": "the-ravens-wing",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-ravens-wing",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_008_x1_demonhunter_male.png",
+	"type": "bow",
+	"quality": "legendary",
+	"name": "The Raven's Wing"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/kridershot",
+	"url_name": "kridershot",
+	"api_url": "https://us.battle.net/api/d3/data/item/kridershot",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_101_x1_demonhunter_male.png",
+	"type": "bow",
+	"quality": "legendary",
+	"name": "Kridershot"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/cluckeye",
+	"url_name": "cluckeye",
+	"api_url": "https://us.battle.net/api/d3/data/item/cluckeye",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_015_x1_demonhunter_male.png",
+	"type": "bow",
+	"quality": "legendary",
+	"name": "Cluckeye"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/windforce",
+	"url_name": "windforce",
+	"api_url": "https://us.battle.net/api/d3/data/item/windforce",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_009_x1_demonhunter_male.png",
+	"type": "bow",
+	"quality": "legendary",
+	"name": "Windforce"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/venomhusk",
+	"url_name": "venomhusk",
+	"api_url": "https://us.battle.net/api/d3/data/item/venomhusk",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_010_1xx_demonhunter_male.png",
+	"type": "bow",
+	"quality": "legendary",
+	"name": "Venomhusk"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/leonine-bow-of-hashir",
+	"url_name": "leonine-bow-of-hashir",
+	"api_url": "https://us.battle.net/api/d3/data/item/leonine-bow-of-hashir",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_103_x1_demonhunter_male.png",
+	"type": "bow",
+	"quality": "legendary",
+	"name": "Leonine Bow of Hashir"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/odysseys-end",
+	"url_name": "odysseys-end",
+	"api_url": "https://us.battle.net/api/d3/data/item/odysseys-end",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_102_x1_demonhunter_male.png",
+	"type": "bow",
+	"quality": "legendary",
+	"name": "Odyssey's End"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/sydyru-crust",
+	"url_name": "sydyru-crust",
+	"api_url": "https://us.battle.net/api/d3/data/item/sydyru-crust",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_010_x1_demonhunter_male.png",
+	"type": "bow",
+	"quality": "legendary",
+	"name": "Sydyru Crust"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/unbound-bolt",
+	"url_name": "unbound-bolt",
+	"api_url": "https://us.battle.net/api/d3/data/item/unbound-bolt",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_007_x1_demonhunter_male.png",
+	"type": "bow",
+	"quality": "legendary",
+	"name": "Unbound Bolt"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/yangs-recurve",
+	"url_name": "yangs-recurve",
+	"api_url": "https://us.battle.net/api/d3/data/item/yangs-recurve",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_bow_104_x1_demonhunter_male.png",
+	"type": "bow",
+	"quality": "legendary",
+	"name": "Yang's Recurve"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/demon-machine",
+	"url_name": "demon-machine",
+	"api_url": "https://us.battle.net/api/d3/data/item/demon-machine",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_xbow_001_x1_demonhunter_male.png",
+	"type": "crossbow",
+	"quality": "legendary",
+	"name": "Demon Machine"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/burizado-kyanon",
+	"url_name": "burizado-kyanon",
+	"api_url": "https://us.battle.net/api/d3/data/item/burizado-kyanon",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_xbow_011_x1_demonhunter_male.png",
+	"type": "crossbow",
+	"quality": "legendary",
+	"name": "Buriza-Do Kyanon"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/bakkan-caster",
+	"url_name": "bakkan-caster",
+	"api_url": "https://us.battle.net/api/d3/data/item/bakkan-caster",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_xbow_006_x1_demonhunter_male.png",
+	"type": "crossbow",
+	"quality": "legendary",
+	"name": "Bakkan Caster"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/pus-spitter",
+	"url_name": "pus-spitter",
+	"api_url": "https://us.battle.net/api/d3/data/item/pus-spitter",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_xbow_012_x1_demonhunter_male.png",
+	"type": "crossbow",
+	"quality": "legendary",
+	"name": "Pus Spitter"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/starspine",
+	"url_name": "starspine",
+	"api_url": "https://us.battle.net/api/d3/data/item/starspine",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_xbow_004_1xx_demonhunter_male.png",
+	"type": "crossbow",
+	"quality": "legendary",
+	"name": "Starspine"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/hellrack",
+	"url_name": "hellrack",
+	"api_url": "https://us.battle.net/api/d3/data/item/hellrack",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_xbow_002_x1_demonhunter_male.png",
+	"type": "crossbow",
+	"quality": "legendary",
+	"name": "Hellrack"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/manticore",
+	"url_name": "manticore",
+	"api_url": "https://us.battle.net/api/d3/data/item/manticore",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_xbow_001_demonhunter_male.png",
+	"type": "crossbow",
+	"quality": "legendary",
+	"name": "Manticore"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/arcane-barb",
+	"url_name": "arcane-barb",
+	"api_url": "https://us.battle.net/api/d3/data/item/arcane-barb",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_xbow_004_x1_demonhunter_male.png",
+	"type": "crossbow",
+	"quality": "legendary",
+	"name": "Arcane Barb"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/chanon-bolter",
+	"url_name": "chanon-bolter",
+	"api_url": "https://us.battle.net/api/d3/data/item/chanon-bolter",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_xbow_101_x1_demonhunter_male.png",
+	"type": "crossbow",
+	"quality": "legendary",
+	"name": "Chanon Bolter"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/wojahnni-assaulter",
+	"url_name": "wojahnni-assaulter",
+	"api_url": "https://us.battle.net/api/d3/data/item/wojahnni-assaulter",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_xbow_102_x1_demonhunter_male.png",
+	"type": "crossbow",
+	"quality": "legendary",
+	"name": "Wojahnni Assaulter"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/vallas-bequest",
+	"url_name": "vallas-bequest",
+	"api_url": "https://us.battle.net/api/d3/data/item/vallas-bequest",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p3_unique_handxbow_005_demonhunter_male.png",
+	"type": "hand-crossbow",
+	"quality": "legendary",
+	"name": "Valla's Bequest"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/helltrapper",
+	"url_name": "helltrapper",
+	"api_url": "https://us.battle.net/api/d3/data/item/helltrapper",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_handxbow_102_x1_demonhunter_male.png",
+	"type": "hand-crossbow",
+	"quality": "legendary",
+	"name": "Helltrapper"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/balefire-caster",
+	"url_name": "balefire-caster",
+	"api_url": "https://us.battle.net/api/d3/data/item/balefire-caster",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_handxbow_004_p1_demonhunter_male.png",
+	"type": "hand-crossbow",
+	"quality": "legendary",
+	"name": "Balefire Caster"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/kmar-tenclip",
+	"url_name": "kmar-tenclip",
+	"api_url": "https://us.battle.net/api/d3/data/item/kmar-tenclip",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_handxbow_101_x1_demonhunter_male.png",
+	"type": "hand-crossbow",
+	"quality": "legendary",
+	"name": "K'mar Tenclip"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/deadeye",
+	"url_name": "deadeye",
+	"api_url": "https://us.battle.net/api/d3/data/item/deadeye",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_handxbow_006_1xx_demonhunter_male.png",
+	"type": "hand-crossbow",
+	"quality": "legendary",
+	"name": "Deadeye"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/dawn",
+	"url_name": "dawn",
+	"api_url": "https://us.battle.net/api/d3/data/item/dawn",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_handxbow_001_demonhunter_male.png",
+	"type": "hand-crossbow",
+	"quality": "legendary",
+	"name": "Dawn"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/calamity",
+	"url_name": "calamity",
+	"api_url": "https://us.battle.net/api/d3/data/item/calamity",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_handxbow_012_x1_demonhunter_male.png",
+	"type": "hand-crossbow",
+	"quality": "legendary",
+	"name": "Calamity"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/danettas-revenge",
+	"url_name": "danettas-revenge",
+	"api_url": "https://us.battle.net/api/d3/data/item/danettas-revenge",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_handxbow_002_x1_demonhunter_male.png",
+	"type": "hand-crossbow",
+	"quality": "set",
+	"name": "Danetta's Revenge"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/danettas-spite",
+	"url_name": "danettas-spite",
+	"api_url": "https://us.battle.net/api/d3/data/item/danettas-spite",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_handxbow_001_x1_demonhunter_male.png",
+	"type": "hand-crossbow",
+	"quality": "set",
+	"name": "Danetta's Spite"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/natalyas-slayer",
+	"url_name": "natalyas-slayer",
+	"api_url": "https://us.battle.net/api/d3/data/item/natalyas-slayer",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_handxbow_003_x1_demonhunter_male.png",
+	"type": "hand-crossbow",
+	"quality": "set",
+	"name": "Natalya's Slayer"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-avenger",
+	"url_name": "hallowed-avenger",
+	"api_url": "https://us.battle.net/api/d3/data/item/hallowed-avenger",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_handxbow_016_1xx_demonhunter_male.png",
+	"type": "hand-crossbow",
+	"quality": "set",
+	"name": "Hallowed Judgment"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/blitzbolter",
+	"url_name": "blitzbolter",
+	"api_url": "https://us.battle.net/api/d3/data/item/blitzbolter",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_handxbow_006_x1_demonhunter_male.png",
+	"type": "hand-crossbow",
+	"quality": "legendary",
+	"name": "Blitzbolter"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/fortress-ballista",
+	"url_name": "fortress-ballista",
+	"api_url": "https://us.battle.net/api/d3/data/item/fortress-ballista",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_handxbow_02_demonhunter_male.png",
+	"type": "hand-crossbow",
+	"quality": "legendary",
+	"name": "Fortress Ballista"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/liannas-wings",
+	"url_name": "liannas-wings",
+	"api_url": "https://us.battle.net/api/d3/data/item/liannas-wings",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_handxbow_01_demonhunter_male.png",
+	"type": "hand-crossbow",
+	"quality": "legendary",
+	"name": "Lianna's Wings"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/the-demons-demise",
+	"url_name": "the-demons-demise",
+	"api_url": "https://us.battle.net/api/d3/data/item/the-demons-demise",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_handxbow_norm_unique_03_demonhunter_male.png",
+	"type": "hand-crossbow",
+	"quality": "legendary",
+	"name": "The Demon's Demise"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-condemnation",
+	"url_name": "hallowed-condemnation",
+	"api_url": "https://us.battle.net/api/d3/data/item/hallowed-condemnation",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_handxbow_016_x1_demonhunter_male.png",
+	"type": "hand-crossbow",
+	"quality": "set",
+	"name": "Hallowed Condemnation"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/starfire",
+	"url_name": "starfire",
+	"api_url": "https://us.battle.net/api/d3/data/item/starfire",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wand_003_x1_demonhunter_male.png",
+	"type": "wand",
+	"quality": "legendary",
+	"name": "Starfire"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/unstable-scepter",
+	"url_name": "unstable-scepter",
+	"api_url": "https://us.battle.net/api/d3/data/item/unstable-scepter",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p1_wand_norm_unique_02_demonhunter_male.png",
+	"type": "wand",
+	"quality": "legendary",
+	"name": "Unstable Scepter"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/blackhand-key",
+	"url_name": "blackhand-key",
+	"api_url": "https://us.battle.net/api/d3/data/item/blackhand-key",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wand_006_x1_demonhunter_male.png",
+	"type": "wand",
+	"quality": "legendary",
+	"name": "Blackhand Key"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/serpents-sparker",
+	"url_name": "serpents-sparker",
+	"api_url": "https://us.battle.net/api/d3/data/item/serpents-sparker",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wand_102_x1_demonhunter_male.png",
+	"type": "wand",
+	"quality": "legendary",
+	"name": "Serpent's Sparker"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/wand-of-woh",
+	"url_name": "wand-of-woh",
+	"api_url": "https://us.battle.net/api/d3/data/item/wand-of-woh",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wand_101_x1_demonhunter_male.png",
+	"type": "wand",
+	"quality": "legendary",
+	"name": "Wand of Woh"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/fragment-of-destiny",
+	"url_name": "fragment-of-destiny",
+	"api_url": "https://us.battle.net/api/d3/data/item/fragment-of-destiny",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p4_unique_wand_010_demonhunter_male.png",
+	"type": "wand",
+	"quality": "legendary",
+	"name": "Fragment of Destiny"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/gesture-of-orpheus",
+	"url_name": "gesture-of-orpheus",
+	"api_url": "https://us.battle.net/api/d3/data/item/gesture-of-orpheus",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p2_unique_wand_002_demonhunter_male.png",
+	"type": "wand",
+	"quality": "legendary",
+	"name": "Gesture of Orpheus"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/sloraks-madness",
+	"url_name": "sloraks-madness",
+	"api_url": "https://us.battle.net/api/d3/data/item/sloraks-madness",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wand_013_x1_demonhunter_male.png",
+	"type": "wand",
+	"quality": "legendary",
+	"name": "Slorak's Madness"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/chantodos-will",
+	"url_name": "chantodos-will",
+	"api_url": "https://us.battle.net/api/d3/data/item/chantodos-will",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wand_012_x1_demonhunter_male.png",
+	"type": "wand",
+	"quality": "set",
+	"name": "Chantodo's Will"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/ruinstoke",
+	"url_name": "ruinstoke",
+	"api_url": "https://us.battle.net/api/d3/data/item/ruinstoke",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wand_009_1xx_demonhunter_male.png",
+	"type": "wand",
+	"quality": "legendary",
+	"name": "Ruinstoke"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-rod",
+	"url_name": "hallowed-rod",
+	"api_url": "https://us.battle.net/api/d3/data/item/hallowed-rod",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wand_018_1xx_demonhunter_male.png",
+	"type": "wand",
+	"quality": "set",
+	"name": "Hallowed Scepter"
+}, {
+	"item_url": "http://us.battle.net/d3/en/item/aether-walker",
+	"url_name": "aether-walker",
+	"api_url": "https://us.battle.net/api/d3/data/item/aether-walker",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/p1_wand_norm_unique_01_demonhunter_male.png",
+	"type": "wand",
+	"quality": "legendary",
+	"name": "Aether Walker"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/atrophy",
+	"url_name": "atrophy",
+	"api_url": "https://us.battle.net/api/d3/data/item/atrophy",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wand_009_x1_demonhunter_male.png",
+	"type": "wand",
+	"quality": "legendary",
+	"name": "Atrophy"
+}, {
+	"item_url": "http://us.battle.net/d3/en/artisan/blacksmith/recipe/hallowed-baton",
+	"url_name": "hallowed-baton",
+	"api_url": "https://us.battle.net/api/d3/data/item/hallowed-baton",
+	"img_url": "http://media.blizzard.com/d3/icons/items/large/unique_wand_018_x1_demonhunter_male.png",
+	"type": "wand",
+	"quality": "set",
+	"name": "Hallowed Baton"
+}]

--- a/public/server.js
+++ b/public/server.js
@@ -108,7 +108,7 @@
 
   function getItemInfos(name) {
     for (let item of itemList) {
-      if (item.name === name) {
+      if (item.name.trim() === name) {
         return [item.type, item.img_url];
       }
     }


### PR DESCRIPTION
Updated to the latest ItemList form the Blizzard API as of 2017-03-10.

The new itemList contained an extra space in the name for Ring of Emptiness which caused loading issues.  Adding a trim() to the item name after it's retrieved from the itemlist.jsoon file fixes the issue. 